### PR TITLE
Rust style: centralized lint policy + best-practice cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,38 @@ serial_test = "3.5"
 [profile.release]
 debug = true
 panic = 'abort'
+
+# Centralized lint policy. Crates opt in with `[lints] workspace = true`.
+# Curated-pragmatic: today's `clippy::all` gate plus a hand-picked set of
+# high-value pedantic/nursery lints; noisy or low-value lints are allowed.
+[workspace.lints.rust]
+unsafe_code = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+# High-value pedantic/nursery lints (CI's `-D warnings` makes these hard errors).
+use_self = "warn"
+uninlined_format_args = "warn"
+semicolon_if_nothing_returned = "warn"
+redundant_clone = "warn"
+explicit_iter_loop = "warn"
+manual_let_else = "warn"
+map_unwrap_or = "warn"
+inefficient_to_string = "warn"
+redundant_closure_for_method_calls = "warn"
+significant_drop_tightening = "warn"
+missing_const_for_fn = "warn"
+# Noisy / low-value in this codebase -> allow.
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+must_use_candidate = "allow"
+# Pedantic, not auto-fixable, and low-value in struct literals where the field
+# type is already obvious -> allow rather than churn every `Default::default()`.
+default_trait_access = "allow"
+module_name_repetitions = "allow"
+doc_markdown = "allow"
+too_many_lines = "allow"

--- a/components/binary/Cargo.toml
+++ b/components/binary/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-binary"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -34,3 +34,6 @@ procfs = "0.16.0"
 [build-dependencies]
 built = { version = "0.8.1", features = ["git2"] }
 const_format = "0.2.34"
+
+[lints]
+workspace = true

--- a/components/binary/src/cmd/format.rs
+++ b/components/binary/src/cmd/format.rs
@@ -90,7 +90,9 @@ pub struct FormatArgs {
 impl FormatArgs {
     fn generate_format(&self) -> Format {
         let mut format = Format {
-            max_capacity: self.capacity.map(|s| s.as_bytes_usize()),
+            max_capacity: self
+                .capacity
+                .map(kiseki_utils::readable_size::ReadableSize::as_bytes_usize),
             block_size: self.block_size.as_bytes_usize(),
             name: self.name.clone(),
             ..Default::default()
@@ -122,36 +124,36 @@ static NAME_REGEX: LazyLock<Result<Regex, regex::Error>> =
 // Validation function for file system names
 fn validate_name(name: &str) -> Result<String, String> {
     if name.len() <= 3 {
-        return Err(format!("File system name {:?} is too short", name));
+        return Err(format!("File system name {name:?} is too short"));
     }
     if name.len() >= 30 {
-        return Err(format!("File system name {:?} is too long", name));
+        return Err(format!("File system name {name:?} is too long"));
     }
     let reg = NAME_REGEX
         .as_ref()
         .map_err(|error| format!("invalid built-in name pattern: {error}"))?;
     if !reg.is_match(name) {
-        return Err(format!("File system name {:?} is invalid", name));
+        return Err(format!("File system name {name:?} is invalid"));
     }
 
     Ok(name.to_string())
 }
 
 fn validate_block_size(s: &str) -> Result<ReadableSize, String> {
-    let n = ReadableSize::from_str(s).map_err(|e| format!("invalid block size: {}", e))?;
+    let n = ReadableSize::from_str(s).map_err(|e| format!("invalid block size: {e}"))?;
     let n = n.as_bytes() as usize;
     let n = align_to_block(n);
     if n < kiseki_common::MIN_BLOCK_SIZE {
-        return Err(format!("block size {} too small", n));
+        return Err(format!("block size {n} too small"));
     }
     if n > kiseki_common::MAX_BLOCK_SIZE {
-        return Err(format!("block size {} too large", n));
+        return Err(format!("block size {n} too large"));
     }
     Ok(ReadableSize(n as u64))
 }
 
 fn validate_capacity(s: &str) -> Result<ReadableSize, String> {
-    let n = ReadableSize::from_str(s).map_err(|e| format!("invalid capacity: {}", e))?;
+    let n = ReadableSize::from_str(s).map_err(|e| format!("invalid capacity: {e}"))?;
     let n = n.as_bytes() as usize;
 
     Ok(ReadableSize(align4k(n as u64) as u64))

--- a/components/binary/src/cmd/mount.rs
+++ b/components/binary/src/cmd/mount.rs
@@ -298,7 +298,7 @@ impl MountArgs {
                 // Stop Agent
                 let agent_ready = agent_running
                     .stop()
-                    .with_whatever_context(|e| format!("failed to stop pyroscope agent {} ", e))?;
+                    .with_whatever_context(|e| format!("failed to stop pyroscope agent {e} "))?;
 
                 // Shutdown the Agent
                 agent_ready.shutdown();
@@ -333,14 +333,14 @@ fn mount(args: MountArgs) -> Result<(), Whatever> {
     validate_mount_point(&args.mount_point)?;
 
     let meta = kiseki_meta::open(meta_config)
-        .with_whatever_context(|e| format!("failed to open meta, {:?}", e))?;
+        .with_whatever_context(|e| format!("failed to open meta, {e:?}"))?;
     let startup_runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .with_whatever_context(|error| format!("failed to build startup runtime: {error}"))?;
     let file_system = startup_runtime
         .block_on(KisekiVFS::new_checked(vfs_config, meta))
-        .with_whatever_context(|e| format!("failed to create file system, {:?}", e))?;
+        .with_whatever_context(|e| format!("failed to create file system, {e:?}"))?;
     drop(startup_runtime);
 
     let fs = kiseki_fuse::KisekiFuse::create(fuse_config.clone(), file_system)?;

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "kiseki-common"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -47,9 +47,9 @@ pub const MIN_FILE_SYSTEM_CAPACITY: usize = 1 << 30; // 1 GiB
 
 pub const MAX_SYMLINK_LEN: usize = 4096;
 
-pub fn cal_chunk_idx(offset: usize, chunk_size: usize) -> usize { offset / chunk_size }
+pub const fn cal_chunk_idx(offset: usize, chunk_size: usize) -> usize { offset / chunk_size }
 
-pub fn cal_chunk_offset(offset: usize, chunk_size: usize) -> usize { offset % chunk_size }
+pub const fn cal_chunk_offset(offset: usize, chunk_size: usize) -> usize { offset % chunk_size }
 
 pub type PageSize = usize;
 pub type BlockIndex = usize;

--- a/components/fuse/Cargo.toml
+++ b/components/fuse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-fuse"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,3 +18,6 @@ kiseki-storage = { path = "../../components/storage" }
 kiseki-types = { path = "../../components/types" }
 kiseki-utils = { path = "../../components/utils" }
 kiseki-vfs = { path = "../../components/vfs" }
+
+[lints]
+workspace = true

--- a/components/fuse/src/lib.rs
+++ b/components/fuse/src/lib.rs
@@ -178,7 +178,7 @@ impl KisekiFuse {
             );
         }
 
-        reply.attr(self.vfs.get_entry_ttl(attr.kind), &attr.to_fuse_attr(inode))
+        reply.attr(self.vfs.get_entry_ttl(attr.kind), &attr.to_fuse_attr(inode));
     }
 }
 
@@ -238,7 +238,7 @@ impl Filesystem for KisekiFuse {
             Ok(attr) => self.reply_attr(&EMPTY_CONTEXT, reply, Ino(ino), attr, true),
             Err(e) => {
                 error!("getattr {ino:?} {e:?}");
-                reply.error(e.to_errno())
+                reply.error(e.to_errno());
             }
         };
     }
@@ -492,7 +492,7 @@ impl Filesystem for KisekiFuse {
             }
             Err(e) => {
                 error!("read {:?} {:?}", Ino(ino), e);
-                reply.error(e.to_errno())
+                reply.error(e.to_errno());
             }
         }
 
@@ -765,7 +765,7 @@ impl Filesystem for KisekiFuse {
 
         match self.runtime.block_on(
             self.vfs
-                .create(ctx.clone(), Ino(parent), &name, mode, umask, flags)
+                .create(ctx, Ino(parent), &name, mode, umask, flags)
                 .in_current_span(),
         ) {
             Ok((entry, fh)) => reply.created(

--- a/components/meta/Cargo.toml
+++ b/components/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-meta"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -48,3 +48,6 @@ rstest.workspace = true
 proptest.workspace = true
 tokio-test.workspace = true
 serial_test.workspace = true
+
+[lints]
+workspace = true

--- a/components/meta/src/backend/key.rs
+++ b/components/meta/src/backend/key.rs
@@ -53,12 +53,12 @@ impl From<Counter> for Vec<u8> {
 impl AsRef<[u8]> for Counter {
     fn as_ref(&self) -> &[u8] {
         match self {
-            Counter::UsedSpace => USED_SPACE.as_bytes(),
-            Counter::TotalInodes => TOTAL_INODES.as_bytes(),
-            Counter::LegacySessions => LEGACY_SESSIONS.as_bytes(),
-            Counter::NextTrash => NEXT_TRASH.as_bytes(),
-            Counter::NextInode => NEXT_INODE.as_bytes(),
-            Counter::NextSlice => NEXT_SLICE.as_bytes(),
+            Self::UsedSpace => USED_SPACE.as_bytes(),
+            Self::TotalInodes => TOTAL_INODES.as_bytes(),
+            Self::LegacySessions => LEGACY_SESSIONS.as_bytes(),
+            Self::NextTrash => NEXT_TRASH.as_bytes(),
+            Self::NextInode => NEXT_INODE.as_bytes(),
+            Self::NextSlice => NEXT_SLICE.as_bytes(),
         }
     }
 }
@@ -66,9 +66,9 @@ impl AsRef<[u8]> for Counter {
 impl Counter {
     pub fn get_step(&self) -> usize {
         match self {
-            Counter::NextTrash => 1,
-            Counter::NextInode => 1 << 10,
-            Counter::NextSlice => 4 << 10,
+            Self::NextTrash => 1,
+            Self::NextInode => 1 << 10,
+            Self::NextSlice => 4 << 10,
             _ => panic!("Counter {self:?} does not have a step"),
         }
     }

--- a/components/meta/src/backend/mod.rs
+++ b/components/meta/src/backend/mod.rs
@@ -58,7 +58,7 @@ impl BackendKinds {
     fn build(&self, path: &str, skip_dir_mtime: Duration) -> Result<BackendRef> {
         match self {
             #[cfg(feature = "meta-rocksdb")]
-            BackendKinds::Rocksdb => {
+            Self::Rocksdb => {
                 let mut builder = rocksdb::Builder::default();
                 builder.with_path(path).with_skip_dir_mtime(skip_dir_mtime);
                 debug!("backend [rocksdb] is built with path: {}", path);

--- a/components/meta/src/backend/rocksdb.rs
+++ b/components/meta/src/backend/rocksdb.rs
@@ -195,7 +195,7 @@ impl Builder {
         self
     }
 
-    pub fn with_skip_dir_mtime(&mut self, d: Duration) -> &mut Self {
+    pub const fn with_skip_dir_mtime(&mut self, d: Duration) -> &mut Self {
         self.skip_dir_mtime = d;
         self
     }
@@ -935,7 +935,7 @@ impl Backend for RocksdbBackend {
             })
             .context(ModelSnafu)?;
         debug!("get_chunk_slices: key: {:?}", String::from_utf8_lossy(&key));
-        for slice in slices.0.iter() {
+        for slice in &slices.0 {
             debug!("get_chunk_slices: slice: {:?}", slice);
         }
         Ok(slices)
@@ -2119,7 +2119,7 @@ mod tests {
     fn test_backend_creation(test_backend: (RocksdbBackend, TempDir)) {
         let (backend, _tempdir) = test_backend;
         // Backend should be created successfully
-        assert!(format!("{:?}", backend).contains("RocksdbEngine"));
+        assert!(format!("{backend:?}").contains("RocksdbEngine"));
     }
 
     #[rstest]

--- a/components/meta/src/engine.rs
+++ b/components/meta/src/engine.rs
@@ -70,13 +70,13 @@ pub fn open(config: MetaConfig) -> Result<MetaEngineRef> {
         root: ROOT_INO,
         session_id: 0,
         open_files,
-        symlinks: Default::default(),
-        removed_files: Default::default(),
+        symlinks: RwLock::default(),
+        removed_files: RwLock::default(),
         // Limit the number of incoming requests being handled at the same time
         delete_semaphore: Arc::new(Semaphore::const_new(100)),
-        dir_parents: Default::default(),
-        fs_stat_used_size: Default::default(),
-        fs_stat_file_count: Default::default(),
+        dir_parents: RwLock::default(),
+        fs_stat_used_size: AtomicU64::default(),
+        fs_stat_file_count: AtomicU64::default(),
         free_inodes: IdTable::new(backend.clone(), Counter::NextInode),
         free_slices: IdTable::new(backend.clone(), Counter::NextSlice),
         backend,
@@ -192,7 +192,7 @@ impl MetaEngine {
 }
 
 impl MetaEngine {
-    pub fn get_format(&self) -> &Format { &self.format }
+    pub const fn get_format(&self) -> &Format { &self.format }
 
     #[instrument(skip(self))]
     pub async fn next_slice_id(&self) -> Result<SliceID> { self.free_slices.next().await }
@@ -746,12 +746,11 @@ impl MetaEngine {
 
         ctx.check_access(&attr, mask)?;
 
-        let attr_flags = match u8::try_from(attr.flags)
+        let Some(attr_flags) = u8::try_from(attr.flags)
             .ok()
             .and_then(kiseki_types::attr::Flags::from_bits)
-        {
-            Some(flags) => flags,
-            None => return LibcSnafu { errno: libc::EIO }.fail(),
+        else {
+            return LibcSnafu { errno: libc::EIO }.fail();
         };
         if (attr_flags.contains(kiseki_types::attr::Flags::IMMUTABLE))
             && flags & (libc::O_WRONLY | libc::O_RDWR) != 0
@@ -770,7 +769,7 @@ impl MetaEngine {
         Ok(attr)
     }
 
-    fn refresh_atime(&self, _ctx: &FuseContext, _inode: Ino) {}
+    const fn refresh_atime(&self, _ctx: &FuseContext, _inode: Ino) {}
 
     // Write put a slice of data on top of the given chunk.
     #[instrument(skip(self, mtime), fields(inode = ? inode, chunk_idx = ? chunk_idx, chunk_pos = ? chunk_pos, slice = ? slice))]
@@ -1026,8 +1025,7 @@ impl MetaEngine {
         }
         drop(read_guard);
         let t = self.backend.do_readlink(inode)?;
-        let mut write_guard = self.symlinks.write().await;
-        write_guard.insert(inode, t.clone());
+        self.symlinks.write().await.insert(inode, t.clone());
         Ok(t)
     }
 }
@@ -1301,7 +1299,7 @@ mod format_tests {
             name: "replacement-volume".to_string(),
             max_capacity: Some(2048),
             max_inodes: Some(256),
-            ..initial.clone()
+            ..initial
         };
         let result = update_format(&dsn, requested, false);
 
@@ -1332,7 +1330,7 @@ mod format_tests {
             name: "renamed-volume".to_string(),
             max_capacity: Some(2048),
             max_inodes: None,
-            ..initial.clone()
+            ..initial
         };
         update_format(&dsn, requested.clone(), true).expect("force mutable update");
 
@@ -1359,7 +1357,7 @@ mod format_tests {
         let requested = Format {
             name: "renamed-volume".to_string(),
             block_size: initial.block_size * 2,
-            ..initial.clone()
+            ..initial
         };
         let result = update_format(&dsn, requested, true);
 

--- a/components/meta/src/err.rs
+++ b/components/meta/src/err.rs
@@ -94,8 +94,8 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn is_not_found(&self) -> bool {
-        matches!(self, Error::ModelError { source, .. } if source.is_not_found())
+    pub const fn is_not_found(&self) -> bool {
+        matches!(self, Self::ModelError { source, .. } if source.is_not_found())
     }
 }
 
@@ -136,30 +136,30 @@ pub mod model_err {
     }
 
     impl Error {
-        pub fn is_not_found(&self) -> bool { matches!(self, Error::NotFound { .. }) }
+        pub const fn is_not_found(&self) -> bool { matches!(self, Self::NotFound { .. }) }
     }
 }
 
 impl ToErrno for Error {
     fn to_errno(&self) -> libc::c_int {
         match self {
-            Error::Unknown { .. } => libc::EINTR,
-            Error::UnsupportedMetaDSN { .. } => libc::EINTR,
-            Error::TokioJoinError { .. } => libc::EINTR,
+            Self::Unknown { .. } => libc::EINTR,
+            Self::UnsupportedMetaDSN { .. } => libc::EINTR,
+            Self::TokioJoinError { .. } => libc::EINTR,
             #[cfg(feature = "meta-rocksdb")]
-            Error::RocksdbError { .. } => libc::EINTR,
-            Error::ModelError { source, .. } => {
+            Self::RocksdbError { .. } => libc::EINTR,
+            Self::ModelError { source, .. } => {
                 if source.is_not_found() {
                     libc::ENOENT
                 } else {
                     libc::EINTR
                 }
             }
-            Error::UninitializedEngine { .. } => libc::EINTR,
-            Error::AlreadyInitialized { .. } => libc::EEXIST,
-            Error::IncompatibleFormat { .. } => libc::EINVAL,
-            Error::InvalidSetting { .. } => libc::EINTR,
-            Error::LibcError { errno, .. } => *errno,
+            Self::UninitializedEngine { .. } => libc::EINTR,
+            Self::AlreadyInitialized { .. } => libc::EEXIST,
+            Self::IncompatibleFormat { .. } => libc::EINVAL,
+            Self::InvalidSetting { .. } => libc::EINTR,
+            Self::LibcError { errno, .. } => *errno,
         }
     }
 }

--- a/components/meta/src/id_table.rs
+++ b/components/meta/src/id_table.rs
@@ -40,6 +40,10 @@ impl IdTable {
     }
 
     /// Return the next unused ID from the table.
+    // The write guard is deliberately held across `increase_count_by` to
+    // serialize ID allocation (the read-modify-write must be atomic), so the
+    // lint's early-drop suggestion does not apply.
+    #[allow(clippy::significant_drop_tightening)]
     pub async fn next(&self) -> Result<u64> {
         let mut next_max_pair = self.next_max_pair.write().await;
         if next_max_pair.0 >= next_max_pair.1 {

--- a/components/meta/src/open_files.rs
+++ b/components/meta/src/open_files.rs
@@ -103,7 +103,7 @@ impl OpenFiles {
         Self {
             ttl,
             _limit: limit,
-            files: Default::default(),
+            files: RwLock::default(),
         }
     }
 
@@ -117,6 +117,10 @@ impl OpenFiles {
 
     /// [`Self::open`] creates a new [OpenFile] if it does not exist; otherwise
     /// it increases the reference count.
+    // The write guard spans a double-checked-lock match with an insert-and-return
+    // arm; the guard already drops before the later `.await`s, and restructuring
+    // the nested match to satisfy the lint would hurt readability.
+    #[allow(clippy::significant_drop_tightening)]
     pub(crate) async fn open(&self, inode: Ino, attr: &mut InodeAttr) {
         let read_guard = self.files.read().await;
         let of = match read_guard.get(&inode) {
@@ -137,7 +141,7 @@ impl OpenFiles {
                                 attr:            attr.keep_cache().clone(),
                                 reference_count: 1,
                                 last_check:      SystemTime::now(),
-                                chunks:          Default::default(),
+                                chunks:          HashMap::default(),
                             }))),
                         );
                         return;

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-storage"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "The core storage implementation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,6 +25,9 @@ moka = { version = "0.12.10", features = ["future"] }
 [dev-dependencies]
 tempfile.workspace = true
 tokio-stream.workspace = true
+
+[lints]
+workspace = true
 
 #[[bench]]
 #name = "bench_main"

--- a/components/storage/src/cache/file_cache.rs
+++ b/components/storage/src/cache/file_cache.rs
@@ -395,12 +395,14 @@ async fn migrate_once(
     )
     .await?;
 
-    let mut staged_index = staged_index.write().await;
-    if staged_index
-        .get(&entry.slice_key)
-        .is_some_and(|current| current.same_generation(entry))
     {
-        staged_index.remove(&entry.slice_key);
+        let mut staged_index = staged_index.write().await;
+        if staged_index
+            .get(&entry.slice_key)
+            .is_some_and(|current| current.same_generation(entry))
+        {
+            staged_index.remove(&entry.slice_key);
+        }
     }
     Ok(())
 }
@@ -886,7 +888,7 @@ mod tests {
         assert_eq!(total_release_page, 1);
 
         let cache_index = cache.index.get(&slice_key).await.unwrap();
-        println!("{:?}", cache_index);
+        println!("{cache_index:?}");
         // we should be able to find the block from local storage.
         let bytes = cache
             .local_storage

--- a/components/storage/src/err.rs
+++ b/components/storage/src/err.rs
@@ -97,8 +97,8 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn is_not_found(&self) -> bool {
-        matches!(self, Error::ObjectStorageError { source, .. } if kiseki_utils::object_storage::is_not_found_error(source))
+    pub const fn is_not_found(&self) -> bool {
+        matches!(self, Self::ObjectStorageError { source, .. } if kiseki_utils::object_storage::is_not_found_error(source))
     }
 }
 

--- a/components/storage/src/lib.rs
+++ b/components/storage/src/lib.rs
@@ -14,8 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unsafe_code)]
-
 pub mod err;
 mod pool;
 

--- a/components/storage/src/pool/disk_pool.rs
+++ b/components/storage/src/pool/disk_pool.rs
@@ -53,7 +53,7 @@ impl DiskPagePool {
         path: P,
         page_size: usize,
         capacity: usize,
-    ) -> Result<Arc<DiskPagePool>> {
+    ) -> Result<Arc<Self>> {
         let start = Instant::now();
         if page_size == 0 || capacity == 0 || !capacity.is_multiple_of(page_size) {
             return InvalidPagePoolConfigSnafu {
@@ -85,7 +85,7 @@ impl DiskPagePool {
             page_size,
             capacity,
             queue,
-            notify: Default::default(),
+            notify: Notify::default(),
             file: RwLock::new(file),
         }))
     }
@@ -112,7 +112,7 @@ impl DiskPagePool {
 
     pub(crate) fn remain_page_cnt(&self) -> usize { self.queue.len() }
 
-    pub(crate) fn total_page_cnt(&self) -> usize { self.capacity / self.page_size }
+    pub(crate) const fn total_page_cnt(&self) -> usize { self.capacity / self.page_size }
 }
 
 impl Display for DiskPagePool {
@@ -148,6 +148,10 @@ impl Page {
         Ok(offset..end)
     }
 
+    // `reader` borrows the mmap read guard for the whole copy, so the guard
+    // cannot drop before the block's tail expression; the lint can't see
+    // through that borrow.
+    #[allow(clippy::significant_drop_tightening)]
     pub(crate) async fn copy_to_writer<W>(
         &self,
         offset: usize,
@@ -158,13 +162,17 @@ impl Page {
         W: tokio::io::AsyncWrite + Unpin + ?Sized,
     {
         let range = self.checked_range(offset, length)?;
-        let guard = self.pool.file.read().await;
-        let mut reader = guard
-            .range_reader(self.cal_offset() + range.start, range.len())
-            .context(DiskPoolMmapSnafu)?;
-        let copy_len = tokio::io::copy(&mut reader, writer)
-            .await
-            .context(UnknownIOSnafu)?;
+        // Hold the mmap read lock only for the duration of the copy, not the
+        // subsequent length validation.
+        let copy_len = {
+            let guard = self.pool.file.read().await;
+            let mut reader = guard
+                .range_reader(self.cal_offset() + range.start, range.len())
+                .context(DiskPoolMmapSnafu)?;
+            tokio::io::copy(&mut reader, writer)
+                .await
+                .context(UnknownIOSnafu)?
+        };
         if copy_len as usize != length {
             return UnexpectedLengthSnafu {
                 subject:  "disk page write",
@@ -176,6 +184,10 @@ impl Page {
         Ok(())
     }
 
+    // `writer` borrows the mmap write guard for the whole copy, so the guard
+    // cannot drop before the block's tail expression; the lint can't see
+    // through that borrow.
+    #[allow(clippy::significant_drop_tightening)]
     pub(crate) async fn copy_from_reader<R>(
         &mut self,
         offset: usize,
@@ -186,13 +198,17 @@ impl Page {
         R: tokio::io::AsyncRead + Unpin + ?Sized,
     {
         let range = self.checked_range(offset, length)?;
-        let mut guard = self.pool.file.write().await;
-        let mut writer = guard
-            .range_writer(self.cal_offset() + range.start, range.len())
-            .context(DiskPoolMmapSnafu)?;
-        let copy_len = tokio::io::copy(reader, &mut writer)
-            .await
-            .context(UnknownIOSnafu)?;
+        // Hold the mmap write lock only for the duration of the copy, not the
+        // subsequent length validation.
+        let copy_len = {
+            let mut guard = self.pool.file.write().await;
+            let mut writer = guard
+                .range_writer(self.cal_offset() + range.start, range.len())
+                .context(DiskPoolMmapSnafu)?;
+            tokio::io::copy(reader, &mut writer)
+                .await
+                .context(UnknownIOSnafu)?
+        };
         if copy_len as usize != length {
             return UnexpectedLengthSnafu {
                 subject:  "disk page read",

--- a/components/storage/src/pool/memory_pool.rs
+++ b/components/storage/src/pool/memory_pool.rs
@@ -59,7 +59,7 @@ impl MemoryPagePool {
             page_size,
             capacity,
             queue: ArrayQueue::new(page_cnt),
-            notify: Default::default(),
+            notify: Notify::default(),
         });
 
         for _ in 0..page_cnt {
@@ -105,11 +105,11 @@ impl MemoryPagePool {
     pub fn remain_page_cnt(&self) -> usize { self.queue.len() }
 
     #[inline]
-    pub fn total_page_cnt(&self) -> usize { self.capacity / self.page_size }
+    pub const fn total_page_cnt(&self) -> usize { self.capacity / self.page_size }
 
     #[allow(dead_code)] // only exercised by tests so far
     #[inline]
-    pub fn capacity(&self) -> usize { self.capacity }
+    pub const fn capacity(&self) -> usize { self.capacity }
 }
 
 impl Display for MemoryPagePool {

--- a/components/storage/src/pool/mod.rs
+++ b/components/storage/src/pool/mod.rs
@@ -65,17 +65,17 @@ pub struct PagePoolBuilder {
 }
 
 impl PagePoolBuilder {
-    pub fn with_page_size(mut self, page_size: usize) -> Self {
+    pub const fn with_page_size(mut self, page_size: usize) -> Self {
         self.page_size = page_size;
         self
     }
 
-    pub fn with_memory_capacity(mut self, memory_capacity: usize) -> Self {
+    pub const fn with_memory_capacity(mut self, memory_capacity: usize) -> Self {
         self.memory_capacity = memory_capacity;
         self
     }
 
-    pub fn with_disk_capacity(mut self, disk_capacity: usize) -> Self {
+    pub const fn with_disk_capacity(mut self, disk_capacity: usize) -> Self {
         self.disk_capacity = Some(disk_capacity);
         self
     }
@@ -202,10 +202,10 @@ impl HybridPagePool {
     }
 
     #[allow(dead_code)] // only exercised by tests so far
-    pub fn total_page_cnt(&self) -> usize { self.total_page_cnt }
+    pub const fn total_page_cnt(&self) -> usize { self.total_page_cnt }
 
     #[allow(dead_code)] // only exercised by tests so far
-    pub fn capacity(&self) -> usize { self.memory_capacity + self.disk_capacity }
+    pub const fn capacity(&self) -> usize { self.memory_capacity + self.disk_capacity }
 
     pub fn free_ratio(&self) -> f64 { self.remain() as f64 / self.total_page_cnt as f64 }
 }
@@ -226,8 +226,8 @@ impl Page {
         W: tokio::io::AsyncWrite + Unpin + ?Sized,
     {
         match self {
-            Page::Memory(page) => page.copy_to_writer(offset, length, writer).await,
-            Page::Disk(page) => page.copy_to_writer(offset, length, writer).await,
+            Self::Memory(page) => page.copy_to_writer(offset, length, writer).await,
+            Self::Disk(page) => page.copy_to_writer(offset, length, writer).await,
         }
     }
 
@@ -241,8 +241,8 @@ impl Page {
         R: tokio::io::AsyncRead + Unpin + ?Sized,
     {
         match self {
-            Page::Memory(page) => page.copy_from_reader(offset, length, reader).await,
-            Page::Disk(page) => page.copy_from_reader(offset, length, reader).await,
+            Self::Memory(page) => page.copy_from_reader(offset, length, reader).await,
+            Self::Disk(page) => page.copy_from_reader(offset, length, reader).await,
         }
     }
 }
@@ -320,7 +320,7 @@ mod tests {
                 let pool = pool.clone();
                 tokio::spawn(async move {
                     let mut page = pool.acquire_page().await;
-                    let mut data = Vec::from(format!("hello {}", i));
+                    let mut data = Vec::from(format!("hello {i}"));
                     let data_len = data.len();
                     let mut cursor = Cursor::new(&mut data);
                     page.copy_from_reader(0, data_len, &mut cursor)

--- a/components/storage/src/slice_buffer.rs
+++ b/components/storage/src/slice_buffer.rs
@@ -352,9 +352,9 @@ impl SliceBuffer {
             .count()
     }
 
-    pub fn flushed_length(&self) -> usize { self.flushed_length }
+    pub const fn flushed_length(&self) -> usize { self.flushed_length }
 
-    pub fn length(&self) -> usize { self.length }
+    pub const fn length(&self) -> usize { self.length }
 
     pub fn status(&self) -> SliceBufferStatus {
         let full_cnt = self.full_block_cnt();
@@ -572,7 +572,7 @@ async fn copy_data_block_to_object_storage(
                 .context(UnknownIOSnafu)?,
             Some(page) => {
                 page.copy_to_writer(page_offset, to_flush_len, &mut writer)
-                    .await?
+                    .await?;
             }
         }
         current_flush_data += to_flush_len;
@@ -625,17 +625,17 @@ struct DataBlock {
 }
 
 impl Block {
-    fn new_data_block() -> Block {
-        Block::Data(DataBlock {
+    fn new_data_block() -> Self {
+        Self::Data(DataBlock {
             length: 0,
             pages:  (0..(BLOCK_SIZE / PAGE_SIZE)).map(|_| None).collect(),
         })
     }
 
-    fn is_full(&self) -> bool {
+    const fn is_full(&self) -> bool {
         match self {
-            Block::Empty => false,
-            Block::Data(db) => db.length == BLOCK_SIZE,
+            Self::Empty => false,
+            Self::Data(db) => db.length == BLOCK_SIZE,
         }
     }
 }

--- a/components/types/Cargo.toml
+++ b/components/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-types"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,3 +20,6 @@ tracing.workspace = true
 
 kiseki-common = { path = "../../components/common" }
 kiseki-utils = { path = "../../components/utils" }
+
+[lints]
+workspace = true

--- a/components/types/src/attr.rs
+++ b/components/types/src/attr.rs
@@ -83,62 +83,62 @@ pub struct InodeAttr {
 
 // Setter
 impl InodeAttr {
-    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
+    pub const fn set_flags(&mut self, flags: u32) -> &mut Self {
         self.flags = flags;
         self
     }
 
-    pub fn set_mode(&mut self, perm: u32) -> &mut Self {
+    pub const fn set_mode(&mut self, perm: u32) -> &mut Self {
         self.mode = perm;
         self
     }
 
-    pub fn set_kind(&mut self, kind: fuser::FileType) -> &mut Self {
+    pub const fn set_kind(&mut self, kind: fuser::FileType) -> &mut Self {
         self.kind = kind;
         self
     }
 
-    pub fn set_nlink(&mut self, nlink: u32) -> &mut Self {
+    pub const fn set_nlink(&mut self, nlink: u32) -> &mut Self {
         self.nlink = nlink;
         self
     }
 
-    pub fn set_length(&mut self, length: u64) -> &mut Self {
+    pub const fn set_length(&mut self, length: u64) -> &mut Self {
         self.length = length;
         self
     }
 
-    pub fn set_rdev(&mut self, rdev: u32) -> &mut Self {
+    pub const fn set_rdev(&mut self, rdev: u32) -> &mut Self {
         self.rdev = rdev;
         self
     }
 
-    pub fn set_gid(&mut self, gid: u32) -> &mut Self {
+    pub const fn set_gid(&mut self, gid: u32) -> &mut Self {
         self.gid = gid;
         self
     }
 
-    pub fn set_uid(&mut self, uid: u32) -> &mut Self {
+    pub const fn set_uid(&mut self, uid: u32) -> &mut Self {
         self.uid = uid;
         self
     }
 
-    pub fn set_parent(&mut self, parent: Ino) -> &mut Self {
+    pub const fn set_parent(&mut self, parent: Ino) -> &mut Self {
         self.parent = parent;
         self
     }
 
-    pub fn set_atime(&mut self, t: SystemTime) -> &mut Self {
+    pub const fn set_atime(&mut self, t: SystemTime) -> &mut Self {
         self.atime = t;
         self
     }
 
-    pub fn set_mtime(&mut self, t: SystemTime) -> &mut Self {
+    pub const fn set_mtime(&mut self, t: SystemTime) -> &mut Self {
         self.mtime = t;
         self
     }
 
-    pub fn set_ctime(&mut self, t: SystemTime) -> &mut Self {
+    pub const fn set_ctime(&mut self, t: SystemTime) -> &mut Self {
         self.ctime = t;
         self
     }
@@ -146,11 +146,11 @@ impl InodeAttr {
 
 // Getter
 impl InodeAttr {
-    pub fn get_filetype(&self) -> FileType { self.kind }
+    pub const fn get_filetype(&self) -> FileType { self.kind }
 
     /// Providing default values guarantees for some critical inode,
     /// makes them always available, even under slow or unreliable conditions.
-    pub fn hard_code_inode_attr(is_trash: bool) -> Self {
+    pub const fn hard_code_inode_attr(is_trash: bool) -> Self {
         Self {
             flags:      0,
             kind:       FileType::Directory,
@@ -169,7 +169,7 @@ impl InodeAttr {
         }
     }
 
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             flags:      0,
             kind:       FileType::Directory,
@@ -188,14 +188,14 @@ impl InodeAttr {
         }
     }
 
-    pub fn keep_cache(&mut self) -> &mut Self {
+    pub const fn keep_cache(&mut self) -> &mut Self {
         self.keep_cache = true;
         self
     }
 
     pub fn update_length(&mut self, length: u64) {
         self.length = length;
-        self.update_modification_time()
+        self.update_modification_time();
     }
 
     pub fn update_modification_time(&mut self) {
@@ -203,7 +203,7 @@ impl InodeAttr {
         self.ctime = SystemTime::now();
     }
 
-    pub fn update_modification_time_with(&mut self, time: SystemTime) {
+    pub const fn update_modification_time_with(&mut self, time: SystemTime) {
         self.mtime = time;
         self.ctime = time;
     }
@@ -304,24 +304,24 @@ impl InodeAttr {
 
     pub fn is_file(&self) -> bool { self.kind == FileType::RegularFile }
 
-    pub fn is_immutable(&self) -> bool {
+    pub const fn is_immutable(&self) -> bool {
         let flag = Flags::from_bits_truncate(self.flags as u8);
         flag.contains(Flags::IMMUTABLE)
     }
 
-    pub fn is_append_only(&self) -> bool {
+    pub const fn is_append_only(&self) -> bool {
         let flag = Flags::from_bits_truncate(self.flags as u8);
         flag.contains(Flags::APPEND)
     }
 
-    pub fn is_normal(&self) -> bool {
+    pub const fn is_normal(&self) -> bool {
         let flag = Flags::from_bits_truncate(self.flags as u8);
         let contains = flag.contains(Flags::IMMUTABLE) || flag.contains(Flags::APPEND);
         !contains
     }
 }
 
-fn get_mode_t_from_filetype(kind: &FileType) -> libc::mode_t {
+const fn get_mode_t_from_filetype(kind: &FileType) -> libc::mode_t {
     match kind {
         FileType::Directory => libc::S_IFDIR,
         FileType::RegularFile => libc::S_IFREG,
@@ -333,7 +333,7 @@ fn get_mode_t_from_filetype(kind: &FileType) -> libc::mode_t {
     }
 }
 
-fn make_smode(kind: &FileType, perm: u32) -> u16 {
+const fn make_smode(kind: &FileType, perm: u32) -> u16 {
     // libc::mode_t is u16 on macOS but u32 on Linux; widen both to u32 for the
     // OR, then narrow to the u16 FUSE perm field (valid modes fit in 16 bits).
     let mode = get_mode_t_from_filetype(kind) as u32;
@@ -352,7 +352,7 @@ impl Default for InodeAttr {
             mode:       0,
             nlink:      1,
             length:     0,
-            parent:     Default::default(),
+            parent:     Ino::default(),
             uid:        0,
             gid:        0,
             rdev:       0,
@@ -385,7 +385,6 @@ mod tests {
         let mode = 0o2777u32;
         let mode_u16 = mode as u16;
         assert_eq!(mode_u16, 0o2777u16);
-        // println!("{:?}", mode as u16)
     }
 
     #[test]
@@ -393,10 +392,10 @@ mod tests {
         let mode = get_mode_t_from_filetype(&FileType::Directory);
         let new_mode = mode | 0o777;
         let new_mode_u16 = new_mode as u16;
-        println!("{:?}, {:?}", new_mode, new_mode_u16);
+        println!("{new_mode:?}, {new_mode_u16:?}");
 
         let x = libc::S_ISUID;
         let x2 = 0o1000;
-        println!("{:x}, {:x}", x, x2)
+        println!("{x:x}, {x2:x}");
     }
 }

--- a/components/types/src/entry.rs
+++ b/components/types/src/entry.rs
@@ -39,7 +39,7 @@ pub struct FullEntry {
 
 impl FullEntry {
     pub fn new(ino: Ino, name: &str, attr: InodeAttr) -> Self {
-        FullEntry {
+        Self {
             inode: ino,
             name: name.to_string(),
             attr,
@@ -61,15 +61,15 @@ pub struct DEntry {
 }
 
 impl Entry {
-    pub fn new_basic_entry_pair(ino: Ino, parent: Ino) -> Vec<Entry> {
+    pub fn new_basic_entry_pair(ino: Ino, parent: Ino) -> Vec<Self> {
         vec![
-            Entry::DEntry(DEntry {
+            Self::DEntry(DEntry {
                 parent: ZERO_INO,
                 name:   DOT.to_string(),
                 inode:  ino,
                 typ:    FileType::Directory,
             }),
-            Entry::DEntry(DEntry {
+            Self::DEntry(DEntry {
                 parent: ZERO_INO,
                 name:   DOT_DOT.to_string(),
                 inode:  parent,
@@ -78,31 +78,31 @@ impl Entry {
         ]
     }
 
-    pub fn get_inode(&self) -> Ino {
+    pub const fn get_inode(&self) -> Ino {
         match self {
-            Entry::Full(e) => e.inode,
-            Entry::DEntry(e) => e.inode,
+            Self::Full(e) => e.inode,
+            Self::DEntry(e) => e.inode,
         }
     }
 
     pub fn is_file(&self) -> bool {
         match self {
-            Entry::Full(e) => e.attr.kind == FileType::RegularFile,
-            Entry::DEntry(e) => e.typ == FileType::RegularFile,
+            Self::Full(e) => e.attr.kind == FileType::RegularFile,
+            Self::DEntry(e) => e.typ == FileType::RegularFile,
         }
     }
 
-    pub fn get_file_type(&self) -> FileType {
+    pub const fn get_file_type(&self) -> FileType {
         match self {
-            Entry::Full(e) => e.attr.kind,
-            Entry::DEntry(e) => e.typ,
+            Self::Full(e) => e.attr.kind,
+            Self::DEntry(e) => e.typ,
         }
     }
 
     pub fn get_name(&self) -> &str {
         match self {
-            Entry::Full(e) => &e.name,
-            Entry::DEntry(e) => &e.name,
+            Self::Full(e) => &e.name,
+            Self::DEntry(e) => &e.name,
         }
     }
 }

--- a/components/types/src/ino.rs
+++ b/components/types/src/ino.rs
@@ -49,7 +49,7 @@ impl AddAssign for Ino {
 }
 
 impl Add for Ino {
-    type Output = Ino;
+    type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output { Self(self.0 + rhs.0) }
 }
@@ -66,9 +66,9 @@ impl Ino {
 
     pub fn is_normal(&self) -> bool { !self.is_special() }
 
-    pub fn is_zero(&self) -> bool { self.0 == 0 }
+    pub const fn is_zero(&self) -> bool { self.0 == 0 }
 
-    pub fn is_root(&self) -> bool { self.0 == ROOT_INO.0 }
+    pub const fn is_root(&self) -> bool { self.0 == ROOT_INO.0 }
 
     // FIXME: use a better way
     // key: AiiiiiiiiI
@@ -81,11 +81,7 @@ impl Ino {
         buf
     }
 
-    pub fn generate_key_str(&self) -> String {
-        // let key_buf = self.generate_key();
-        // String::from_utf8_lossy(&key_buf).to_string()
-        format!("A{:x}I", self.0)
-    }
+    pub fn generate_key_str(&self) -> String { format!("A{:x}I", self.0) }
 }
 
 #[cfg(test)]
@@ -95,8 +91,8 @@ mod tests {
     #[test]
     fn ino() {
         let key = ROOT_INO.generate_key();
-        println!("{:?}", key);
+        println!("{key:?}");
         let key_str = ROOT_INO.generate_key_str();
-        println!("{:?}", key_str)
+        println!("{key_str:?}");
     }
 }

--- a/components/types/src/setting.rs
+++ b/components/types/src/setting.rs
@@ -78,7 +78,7 @@ pub struct Format {
 
 impl Default for Format {
     fn default() -> Self {
-        Format {
+        Self {
             name:         String::from(KISEKI),
             chunk_size:   CHUNK_SIZE, // 64MB
             block_size:   BLOCK_SIZE, // 4MB

--- a/components/types/src/slice.rs
+++ b/components/types/src/slice.rs
@@ -75,7 +75,7 @@ pub type OverlookedSlicesRef = Arc<OverlookedSlices>;
 pub struct Slices(pub Vec<Slice>);
 
 impl Slices {
-    pub fn decode(buf: &[u8]) -> Result<Slices, Error> {
+    pub fn decode(buf: &[u8]) -> Result<Self, Error> {
         ensure!(
             buf.len().is_multiple_of(SLICE_BYTES),
             InvalidSliceBufSnafu { len: buf.len() }
@@ -87,7 +87,7 @@ impl Slices {
             slices.push(slice);
             i += SLICE_BYTES;
         }
-        Ok(Slices(slices))
+        Ok(Self(slices))
     }
 
     /// Look over all slices and build a RangeMap for them.
@@ -97,14 +97,14 @@ impl Slices {
             rm.insert(
                 s.get_chunk_pos()..s.get_chunk_pos() + s.get_size(),
                 s.clone(),
-            )
+            );
         });
         rm
     }
 
-    pub fn len(&self) -> usize { self.0.len() }
+    pub const fn len(&self) -> usize { self.0.len() }
 
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub const fn is_empty(&self) -> bool { self.0.is_empty() }
 }
 
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -137,7 +137,7 @@ pub enum Slice {
 impl Debug for Slice {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Slice::Owned {
+            Self::Owned {
                 chunk_pos,
                 id,
                 size,
@@ -150,7 +150,7 @@ impl Debug for Slice {
                 ReadableSize(*size as u64),
                 _padding
             ),
-            Slice::Borrowed {
+            Self::Borrowed {
                 chunk_pos,
                 id,
                 size,
@@ -170,8 +170,8 @@ impl Debug for Slice {
 }
 
 impl Slice {
-    pub fn new_owned(chunk_pos: usize, slice_id: u64, size: usize) -> Self {
-        Slice::Owned {
+    pub const fn new_owned(chunk_pos: usize, slice_id: u64, size: usize) -> Self {
+        Self::Owned {
             chunk_pos: chunk_pos as u32,
             id:        slice_id,
             size:      size as u32,
@@ -184,45 +184,45 @@ impl Slice {
             buf.len() >= SLICE_BYTES,
             InvalidSliceBufSnafu { len: buf.len() }
         );
-        let x: Slice = bincode::deserialize(buf).context(DecodeSliceBufSnafu)?;
+        let x: Self = bincode::deserialize(buf).context(DecodeSliceBufSnafu)?;
         Ok(x)
     }
 
     pub fn get_chunk_pos(&self) -> usize {
         (match self {
-            Slice::Owned { chunk_pos, .. } => *chunk_pos,
-            Slice::Borrowed { chunk_pos, off, .. } => *chunk_pos + off,
+            Self::Owned { chunk_pos, .. } => *chunk_pos,
+            Self::Borrowed { chunk_pos, off, .. } => *chunk_pos + off,
         }) as usize
     }
 
-    pub fn get_id(&self) -> SliceID {
+    pub const fn get_id(&self) -> SliceID {
         match self {
-            Slice::Owned { id: slice_id, .. } => *slice_id,
-            Slice::Borrowed { id: slice_id, .. } => *slice_id,
+            Self::Owned { id: slice_id, .. } => *slice_id,
+            Self::Borrowed { id: slice_id, .. } => *slice_id,
         }
     }
 
-    pub fn get_size(&self) -> usize {
+    pub const fn get_size(&self) -> usize {
         (match self {
-            Slice::Owned { size, .. } => *size,
+            Self::Owned { size, .. } => *size,
             // for borrowed slice, the size is the length of the borrowed part.
-            Slice::Borrowed { len, .. } => *len,
+            Self::Borrowed { len, .. } => *len,
         }) as usize
     }
 
-    pub fn get_underlying_size(&self) -> usize {
+    pub const fn get_underlying_size(&self) -> usize {
         (match self {
-            Slice::Owned { size, .. } => *size,
-            Slice::Borrowed { size, .. } => *size,
+            Self::Owned { size, .. } => *size,
+            Self::Borrowed { size, .. } => *size,
         }) as usize
     }
 
     /// Return the byte offset where this logical slice starts in its backing
     /// object.
-    pub fn get_underlying_offset(&self) -> usize {
+    pub const fn get_underlying_offset(&self) -> usize {
         match self {
-            Slice::Owned { .. } => 0,
-            Slice::Borrowed { off, .. } => *off as usize,
+            Self::Owned { .. } => 0,
+            Self::Borrowed { off, .. } => *off as usize,
         }
     }
 }
@@ -270,7 +270,7 @@ impl PartialOrd for SliceKey {
 }
 
 impl SliceKey {
-    pub fn new(slice_id: SliceID, block_idx: usize, block_size: usize) -> Self {
+    pub const fn new(slice_id: SliceID, block_idx: usize, block_size: usize) -> Self {
         Self {
             slice_id,
             block_idx,
@@ -278,12 +278,12 @@ impl SliceKey {
         }
     }
 
-    pub fn gen_path_for_local_sto(&self) -> String { format!("{}", self) }
+    pub fn gen_path_for_local_sto(&self) -> String { format!("{self}") }
 
-    pub fn gen_path_for_object_sto(&self) -> String { format!("chunks{}", self) }
+    pub fn gen_path_for_object_sto(&self) -> String { format!("chunks{self}") }
 
     pub fn random() -> Self {
-        SliceKey {
+        Self {
             slice_id:   ID_GENERATOR.next_id().expect("failed to generate id"),
             block_idx:  0,
             block_size: 0,
@@ -304,7 +304,7 @@ impl SliceKey {
 impl TryFrom<&str> for SliceKey {
     type Error = Error;
 
-    fn try_from(s: &str) -> Result<Self, Self::Error> { SliceKey::from_str(s) }
+    fn try_from(s: &str) -> Result<Self, Self::Error> { Self::from_str(s) }
 }
 
 impl FromStr for SliceKey {
@@ -323,7 +323,7 @@ impl FromStr for SliceKey {
         let parse_hex = |field: &str| {
             u64::from_str_radix(field, 16).context(ParseSliceKeyFailedSnafu { str: s.to_string() })
         };
-        let key = SliceKey {
+        let key = Self {
             slice_id:   parse_hex(slice_id)?,
             block_idx:  usize::try_from(parse_hex(block_idx)?)
                 .map_err(|_| InvalidSliceKeyStrSnafu { str: s.to_string() }.build())?,

--- a/components/types/src/stat.rs
+++ b/components/types/src/stat.rs
@@ -49,7 +49,7 @@ impl Debug for FSStat {
 
 impl Default for FSStat {
     fn default() -> Self {
-        FSStat {
+        Self {
             total_size: u64::MAX,
             used_size:  0,
             file_count: 0,

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-utils"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -57,3 +57,6 @@ rustix = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/components/utils/src/align.rs
+++ b/components/utils/src/align.rs
@@ -17,7 +17,7 @@
 use kiseki_common::{MAX_BLOCK_SIZE, MIN_BLOCK_SIZE};
 use tracing::warn;
 
-pub fn align4k(length: u64) -> i64 {
+pub const fn align4k(length: u64) -> i64 {
     if length == 0 {
         return 1 << 12; // 4096
     }

--- a/components/utils/src/logger.rs
+++ b/components/utils/src/logger.rs
@@ -88,6 +88,10 @@ impl LoggingOptions {
 const DEFAULT_LOG_TARGETS: &str = "info";
 
 #[allow(clippy::print_stdout)]
+// The otlp `exporter` temporary is moved into the tracer provider builder a few
+// lines later; keeping the intermediate binding reads far clearer than nesting
+// its multi-line `.build().expect(...)` inside `.with_batch_exporter(...)`.
+#[allow(clippy::significant_drop_tightening)]
 pub fn init_global_logging(
     app_name: &str,
     opts: &LoggingOptions,
@@ -149,8 +153,7 @@ pub fn init_global_logging(
     // let filter = Targets::new().with_target("kiseki", LevelFilter::DEBUG);
     let sampler = opts
         .tracing_sample_ratio
-        .map(Sampler::TraceIdRatioBased)
-        .unwrap_or(Sampler::AlwaysOn);
+        .map_or(Sampler::AlwaysOn, Sampler::TraceIdRatioBased);
 
     let (sentry_layer, sentry_guard) = match init_sentry() {
         None => (None, None),
@@ -197,12 +200,11 @@ pub fn init_global_logging(
 
     if enable_otlp_tracing {
         global::set_text_map_propagator(TraceContextPropagator::new());
-        let endpoint = opts
-            .otlp_endpoint
-            .as_ref()
-            .map(|e| format!("http://{}", e))
-            .unwrap_or(DEFAULT_OTLP_ENDPOINT.to_string());
-        println!("find otlp tracing config: {}", endpoint);
+        let endpoint = opts.otlp_endpoint.as_ref().map_or_else(
+            || DEFAULT_OTLP_ENDPOINT.to_string(),
+            |e| format!("http://{e}"),
+        );
+        println!("find otlp tracing config: {endpoint}");
         let exporter = opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
             .with_endpoint(endpoint)

--- a/components/utils/src/object_storage.rs
+++ b/components/utils/src/object_storage.rs
@@ -139,7 +139,7 @@ impl ObjectStorageConfig {
         }
     }
 
-    pub fn provider(&self) -> &'static str {
+    pub const fn provider(&self) -> &'static str {
         match self {
             Self::Memory => "memory",
             Self::File { .. } => "file",
@@ -373,7 +373,7 @@ async fn probe_list(
     Ok(())
 }
 
-pub fn is_not_found_error(e: &ObjectStorageError) -> bool {
+pub const fn is_not_found_error(e: &ObjectStorageError) -> bool {
     matches!(e, ObjectStorageError::NotFound { .. })
 }
 

--- a/components/utils/src/pyroscope_init.rs
+++ b/components/utils/src/pyroscope_init.rs
@@ -29,7 +29,7 @@ pub fn init_pyroscope() -> Result<Option<Guard>, Whatever> {
     }
 
     let url = url.unwrap();
-    println!("found pyroscope url: {}, starting pyroscope agent ...", url);
+    println!("found pyroscope url: {url}, starting pyroscope agent ...");
 
     let agent = PyroscopeAgent::builder(url, String::from("kiseki"))
         .backend(pprof_backend(PprofConfig::new().sample_rate(100)))

--- a/components/utils/src/readable_size.rs
+++ b/components/utils/src/readable_size.rs
@@ -41,11 +41,11 @@ pub const PIB: u64 = TIB * BINARY_DATA_MAGNITUDE;
 pub struct ReadableSize(pub u64);
 
 impl ReadableSize {
-    pub const fn kb(count: u64) -> ReadableSize { ReadableSize(count * KIB) }
+    pub const fn kb(count: u64) -> Self { Self(count * KIB) }
 
-    pub const fn mb(count: u64) -> ReadableSize { ReadableSize(count * MIB) }
+    pub const fn mb(count: u64) -> Self { Self(count * MIB) }
 
-    pub const fn gb(count: u64) -> ReadableSize { ReadableSize(count * GIB) }
+    pub const fn gb(count: u64) -> Self { Self(count * GIB) }
 
     pub const fn as_mb(self) -> u64 { self.0 / MIB }
 
@@ -55,21 +55,21 @@ impl ReadableSize {
 }
 
 impl Div<u64> for ReadableSize {
-    type Output = ReadableSize;
+    type Output = Self;
 
-    fn div(self, rhs: u64) -> ReadableSize { ReadableSize(self.0 / rhs) }
+    fn div(self, rhs: u64) -> Self { Self(self.0 / rhs) }
 }
 
-impl Div<ReadableSize> for ReadableSize {
+impl Div<Self> for ReadableSize {
     type Output = u64;
 
-    fn div(self, rhs: ReadableSize) -> u64 { self.0 / rhs.0 }
+    fn div(self, rhs: Self) -> u64 { self.0 / rhs.0 }
 }
 
 impl Mul<u64> for ReadableSize {
-    type Output = ReadableSize;
+    type Output = Self;
 
-    fn mul(self, rhs: u64) -> ReadableSize { ReadableSize(self.0 * rhs) }
+    fn mul(self, rhs: u64) -> Self { Self(self.0 * rhs) }
 }
 
 impl Serialize for ReadableSize {
@@ -80,7 +80,7 @@ impl Serialize for ReadableSize {
         let size = self.0;
         let mut buffer = String::new();
         if size == 0 {
-            write!(buffer, "{}KiB", size).unwrap();
+            write!(buffer, "{size}KiB").unwrap();
         } else if size.is_multiple_of(PIB) {
             write!(buffer, "{}PiB", size / PIB).unwrap();
         } else if size.is_multiple_of(TIB) {
@@ -102,14 +102,14 @@ impl FromStr for ReadableSize {
     type Err = String;
 
     // This method parses value in binary unit.
-    fn from_str(s: &str) -> Result<ReadableSize, String> {
+    fn from_str(s: &str) -> Result<Self, String> {
         let size_str = s.trim();
         if size_str.is_empty() {
-            return Err(format!("{:?} is not a valid size.", s));
+            return Err(format!("{s:?} is not a valid size."));
         }
 
         if !size_str.is_ascii() {
-            return Err(format!("ASCII string is expected, but got {:?}", s));
+            return Err(format!("ASCII string is expected, but got {s:?}"));
         }
 
         // size: digits and '.' as decimal separator
@@ -131,21 +131,20 @@ impl FromStr for ReadableSize {
             "B" | "" => B,
             _ => {
                 return Err(format!(
-                    "only B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, and PiB are supported: {:?}",
-                    s
+                    "only B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, and PiB are supported: {s:?}"
                 ));
             }
         };
 
         match size.parse::<f64>() {
-            Ok(n) => Ok(ReadableSize((n * unit as f64) as u64)),
-            Err(_) => Err(format!("invalid size string: {:?}", s)),
+            Ok(n) => Ok(Self((n * unit as f64) as u64)),
+            Err(_) => Err(format!("invalid size string: {s:?}")),
         }
     }
 }
 
 impl Debug for ReadableSize {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{self}") }
 }
 
 impl Display for ReadableSize {

--- a/components/utils/src/sentry_init.rs
+++ b/components/utils/src/sentry_init.rs
@@ -32,7 +32,7 @@ pub struct SentryConfig {
 impl SentryConfig {
     pub fn from_environment() -> Result<Self, Whatever> {
         let dsn = var("SENTRY_DSN")?.into_dsn().with_whatever_context(|e| {
-            format!("SENTRY_DSN_API is not a valid Sentry DSN value {}", e)
+            format!("SENTRY_DSN_API is not a valid Sentry DSN value {e}")
         })?;
 
         let environment =
@@ -73,7 +73,7 @@ pub fn init_sentry() -> Option<ClientInitGuard> {
         }
     };
 
-    println!("found sentry config: {:?}", config);
+    println!("found sentry config: {config:?}");
 
     let opts = sentry::ClientOptions {
         auto_session_tracking: true,

--- a/components/vfs/Cargo.toml
+++ b/components/vfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kiseki-vfs"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -35,3 +35,6 @@ rstest.workspace = true
 proptest.workspace = true
 tokio-test.workspace = true
 serial_test.workspace = true
+
+[lints]
+workspace = true

--- a/components/vfs/src/handle.rs
+++ b/components/vfs/src/handle.rs
@@ -50,7 +50,7 @@ pub(crate) struct HandleTable {
 
 impl HandleTable {
     pub(crate) fn new(data_manager_ref: DataManagerRef) -> HandleTableRef {
-        Arc::new(HandleTable {
+        Arc::new(Self {
             data_manager: data_manager_ref,
             handles:      Default::default(),
             next_fh:      AtomicU64::new(1),
@@ -165,29 +165,29 @@ pub(crate) enum Handle {
 impl Handle {
     pub(crate) fn get_fh(&self) -> FH {
         match self {
-            Handle::File(h) => h.fh,
-            Handle::Dir(h) => h.fh,
+            Self::File(h) => h.fh,
+            Self::Dir(h) => h.fh,
         }
     }
 
     pub(crate) fn as_file_handle(&self) -> Option<Arc<FileHandle>> {
         match self {
-            Handle::File(h) => Some(h.clone()),
+            Self::File(h) => Some(h.clone()),
             _ => None,
         }
     }
 
     pub(crate) fn as_dir_handle(&self) -> Option<Arc<DirHandle>> {
         match self {
-            Handle::Dir(h) => Some(h.clone()),
+            Self::Dir(h) => Some(h.clone()),
             _ => None,
         }
     }
 
     pub(crate) async fn wait_all_operations_done(&self, ctx: Arc<FuseContext>) -> Result<()> {
         match self {
-            Handle::File(h) => h.wait_all_operations_done(Some(ctx)).await,
-            Handle::Dir(_) => Ok(()),
+            Self::File(h) => h.wait_all_operations_done(Some(ctx)).await,
+            Self::Dir(_) => Ok(()),
         }
     }
 }
@@ -231,7 +231,7 @@ impl FileHandle {
         fr: Arc<FileReader>,
         fw: Option<Arc<FileWriter>>,
     ) -> Self {
-        FileHandle {
+        Self {
             fh,
             inode,
             reader: fr,
@@ -255,7 +255,7 @@ impl FileHandle {
             .compare_exchange(lock_owner, 0, Ordering::AcqRel, Ordering::Relaxed);
     }
 
-    pub(crate) fn has_writer(&self) -> bool { self.writer.is_some() }
+    pub(crate) const fn has_writer(&self) -> bool { self.writer.is_some() }
 
     pub(crate) async fn read_lock(&self, ctx: Arc<FuseContext>) -> Option<FileHandleReadGuard> {
         let cancel_token = ctx.cancellation_token.clone();
@@ -280,8 +280,9 @@ impl FileHandle {
             self.reader_cnt.fetch_sub(1, Ordering::AcqRel);
             return None;
         };
-        let mut write_guard = self.operations.write().await;
-        write_guard
+        self.operations
+            .write()
+            .await
             .entry(ctx.pid)
             .or_default()
             .insert(ctx.unique, ctx.clone());
@@ -313,10 +314,10 @@ impl FileHandle {
                 // released.
                 tokio::select! {
                     _ = self.exclusive_lock_notify.notified() => {
-                        debug!("exclusive lock is released")
+                        debug!("exclusive lock is released");
                     }
                     _ = self.reader_notify.notified() => {
-                        debug!("reader is released")
+                        debug!("reader is released");
                     }
                     _ = cancel_token.cancelled() => {
                         // decrease the write wait count
@@ -344,8 +345,9 @@ impl FileHandle {
             return None;
         }
 
-        let mut write_guard = self.operations.write().await;
-        write_guard
+        self.operations
+            .write()
+            .await
             .entry(ctx.pid)
             .or_default()
             .insert(ctx.unique, ctx.clone());
@@ -399,10 +401,10 @@ impl FileHandle {
             if let Some(cancel_token) = cancel_token.as_ref() {
                 tokio::select! {
                     _ = self.exclusive_lock_notify.notified() => {
-                        debug!("exclusive lock is released")
+                        debug!("exclusive lock is released");
                     }
                     _ = self.reader_notify.notified() => {
-                        debug!("reader is released")
+                        debug!("reader is released");
                     }
                     _ = cancel_token.cancelled() => {
                         error!("wait all operations done is cancelled");
@@ -412,10 +414,10 @@ impl FileHandle {
             } else {
                 tokio::select! {
                     _ = self.exclusive_lock_notify.notified() => {
-                        debug!("exclusive lock is released")
+                        debug!("exclusive lock is released");
                     }
                     _ = self.reader_notify.notified() => {
-                        debug!("reader is released")
+                        debug!("reader is released");
                     }
                 }
             }
@@ -488,7 +490,7 @@ impl Drop for FileHandleReadGuard {
     fn drop(&mut self) {
         debug!("read lock is released");
         self.reader_cnt.fetch_sub(1, Ordering::AcqRel);
-        self.reader_notify.notify_waiters()
+        self.reader_notify.notify_waiters();
     }
 }
 
@@ -501,7 +503,7 @@ pub(crate) struct DirHandle {
 
 impl DirHandle {
     fn new(inode: Ino, fh: FH) -> Self {
-        DirHandle {
+        Self {
             fh,
             inode,
             inner: RwLock::new(DirHandleInner {

--- a/components/vfs/src/kiseki.rs
+++ b/components/vfs/src/kiseki.rs
@@ -276,7 +276,7 @@ impl KisekiVFS {
     /// - Subdirectory chroot operation fails (when configured)
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_meta::context::FuseContext;
     ///
     /// let ctx = FuseContext::background();
@@ -392,7 +392,7 @@ impl KisekiVFS {
     /// - Permission denied for the requested inode
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     ///
     /// let stats = vfs.stat_fs(ctx.clone(), ROOT_INO)?;

--- a/components/vfs/src/kiseki/file_io.rs
+++ b/components/vfs/src/kiseki/file_io.rs
@@ -79,7 +79,7 @@ impl KisekiVFS {
     /// - Delegates permission checking to the metadata engine
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use libc::{O_CREAT, O_RDWR};
     ///
     /// let opened = vfs.open(&ctx, inode, O_RDWR).await?;
@@ -98,7 +98,7 @@ impl KisekiVFS {
         let mut attr = if inode.is_special() {
             self.internal_nodes
                 .get_internal_node(inode)
-                .map(|node| node.get_attr())
+                .map(kiseki_types::internal_nodes::InternalNode::get_attr)
                 .context(LibcSnafu { errno: ENOENT })?
         } else {
             self.meta
@@ -165,7 +165,7 @@ impl KisekiVFS {
     /// - Reads through the data manager for caching and buffering
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// let data = vfs.read(ctx.clone(), inode, fh, 0, 1024, 0, None).await?;
     /// println!("Read {} bytes", data.len());
     /// ```
@@ -265,7 +265,7 @@ impl KisekiVFS {
     /// - May extend the file size if writing beyond current EOF
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// let data = b"Hello, world!";
     /// let written = vfs
     ///     .write(ctx.clone(), inode, fh, 0, data, 0, 0, None)
@@ -360,7 +360,7 @@ impl KisekiVFS {
     /// - Releases POSIX locks if held by the lock owner
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// vfs.flush(ctx.clone(), inode, fh, lock_owner).await?;
     /// println!("File flushed successfully");
     /// ```
@@ -461,7 +461,7 @@ impl KisekiVFS {
     /// - Coordinates with concurrent operations through file handle locking
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// vfs.fsync(ctx.clone(), inode, fh, false).await?;
     /// println!("File data synchronized to storage");
     /// ```

--- a/components/vfs/src/kiseki/metadata.rs
+++ b/components/vfs/src/kiseki/metadata.rs
@@ -70,7 +70,7 @@ impl KisekiVFS {
     /// - Internal nodes are synthetic and don't exist in the metadata store
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     ///
     /// // Look up a file in the root directory
@@ -141,7 +141,7 @@ impl KisekiVFS {
     /// - Internal nodes have predefined attributes and behavior
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     ///
     /// let attr = vfs.get_attr(ROOT_INO).await?;
@@ -210,7 +210,7 @@ impl KisekiVFS {
     /// - Permission checks are performed when ctx.check_permission is true
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use fuser::TimeOrNow;
     /// use kiseki_types::attr::SetAttrFlags;
     ///

--- a/components/vfs/src/kiseki/namespace.rs
+++ b/components/vfs/src/kiseki/namespace.rs
@@ -64,6 +64,10 @@ impl KisekiVFS {
         Ok(self.handle_table.new_dir_handle(inode).await)
     }
 
+    // The directory handle's write lock is deliberately held across
+    // `meta.read_dir` to atomically populate its cached children; releasing it
+    // earlier would reintroduce the TOCTOU the double-checked lock avoids.
+    #[allow(clippy::significant_drop_tightening)]
     pub async fn read_dir<I: Into<Ino>>(
         &self,
         ctx: &FuseContext,
@@ -143,7 +147,7 @@ impl KisekiVFS {
     /// - Permissions are modified by umask before setting
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     ///
     /// let new_dir = vfs
@@ -298,7 +302,7 @@ impl KisekiVFS {
     /// - Updates file reader length before returning the handle
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     /// use libc::O_RDWR;
     ///
@@ -528,7 +532,7 @@ impl KisekiVFS {
     /// - Handles both file and directory renaming
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```ignore
     /// use kiseki_types::ino::ROOT_INO;
     ///
     /// // Rename a file in the same directory

--- a/components/vfs/src/kiseki/tests.rs
+++ b/components/vfs/src/kiseki/tests.rs
@@ -359,7 +359,7 @@ mod file_operations {
         #[case] _desc: &str,
     ) -> Result<()> {
         let env = vfs_env.await;
-        let filename = format!("file_{}_bytes", size);
+        let filename = format!("file_{size}_bytes");
         let (entry, fh) =
             test_utils::create_test_file(&env.vfs, env.ctx.clone(), ROOT_INO, &filename, 0o644)
                 .await?;
@@ -1018,12 +1018,7 @@ mod concurrent_operations {
                     .release(ctx_clone, opened.inode, opened.fh)
                     .await?;
 
-                assert_eq!(
-                    read_data.as_ref(),
-                    initial_data,
-                    "任务{}读取的数据应一致",
-                    i
-                );
+                assert_eq!(read_data.as_ref(), initial_data, "任务{i}读取的数据应一致");
                 Ok(())
             });
         }
@@ -1053,7 +1048,7 @@ mod concurrent_operations {
             let ctx_clone = ctx.clone();
 
             tasks.spawn(async move {
-                let dir_name = format!("concurrent_dir_{}", i);
+                let dir_name = format!("concurrent_dir_{i}");
                 let dir = vfs_clone
                     .mkdir(ctx_clone.clone(), ROOT_INO, &dir_name, 0o755, 0)
                     .await?;
@@ -1143,7 +1138,7 @@ mod boundary_conditions {
         #[case] _desc: &str,
     ) -> Result<()> {
         let env = vfs_env.await;
-        let filename = format!("edge_file_{}", size);
+        let filename = format!("edge_file_{size}");
         let (file, fh) =
             test_utils::create_test_file(&env.vfs, env.ctx.clone(), ROOT_INO, &filename, 0o644)
                 .await?;
@@ -1385,7 +1380,7 @@ mod attribute_operations {
         #[case] _desc: &str,
     ) -> Result<()> {
         let env = vfs_env.await;
-        let filename = format!("perm_test_{:o}", mode);
+        let filename = format!("perm_test_{mode:o}");
         let (file, fh) =
             test_utils::create_test_file(&env.vfs, env.ctx.clone(), ROOT_INO, &filename, mode)
                 .await?;
@@ -1420,7 +1415,7 @@ mod performance_tests {
 
         // 创建多个文件并测量性能
         for i in 0..file_count {
-            let filename = format!("perf_file_{}", i);
+            let filename = format!("perf_file_{i}");
             let (file, fh) =
                 test_utils::create_test_file(&vfs, ctx.clone(), ROOT_INO, &filename, 0o644).await?;
             vfs.release(ctx.clone(), file.inode, fh).await?;
@@ -1432,11 +1427,10 @@ mod performance_tests {
         // 验证性能至少达到合理水平 (比如每秒50个文件)
         assert!(
             files_per_sec > 50.0,
-            "文件创建性能太低：{:.2} files/sec",
-            files_per_sec
+            "文件创建性能太低：{files_per_sec:.2} files/sec"
         );
 
-        println!("文件创建性能：{:.2} files/sec", files_per_sec);
+        println!("文件创建性能：{files_per_sec:.2} files/sec");
 
         Ok(())
     }
@@ -1451,7 +1445,7 @@ mod performance_tests {
 
         // 创建多个目录
         for i in 0..dir_count {
-            let dirname = format!("perf_dir_{}", i);
+            let dirname = format!("perf_dir_{i}");
             let _dir = vfs.mkdir(ctx.clone(), ROOT_INO, &dirname, 0o755, 0).await?;
         }
 
@@ -1470,22 +1464,20 @@ mod performance_tests {
         // 验证目录创建性能
         assert!(
             dirs_per_sec > 100.0,
-            "目录创建性能太低：{:.2} dirs/sec",
-            dirs_per_sec
+            "目录创建性能太低：{dirs_per_sec:.2} dirs/sec"
         );
 
         // 验证目录列举性能 (应该很快)
         assert!(
             list_elapsed.as_millis() < 100,
-            "目录列举太慢：{:?}",
-            list_elapsed
+            "目录列举太慢：{list_elapsed:?}"
         );
 
         // 验证列举结果正确
         assert_eq!(entries.len(), dir_count, "列举的目录数应匹配");
 
-        println!("目录创建性能：{:.2} dirs/sec", dirs_per_sec);
-        println!("目录列举性能：{:?}", list_elapsed);
+        println!("目录创建性能：{dirs_per_sec:.2} dirs/sec");
+        println!("目录列举性能：{list_elapsed:?}");
 
         Ok(())
     }
@@ -1527,17 +1519,15 @@ mod performance_tests {
         // 验证I/O性能至少达到1MB/s (这是很保守的要求)
         assert!(
             write_throughput > 1.0,
-            "写入吞吐量太低：{:.2} MB/s",
-            write_throughput
+            "写入吞吐量太低：{write_throughput:.2} MB/s"
         );
         assert!(
             read_throughput > 1.0,
-            "读取吞吐量太低：{:.2} MB/s",
-            read_throughput
+            "读取吞吐量太低：{read_throughput:.2} MB/s"
         );
 
-        println!("写入性能：{:.2} MB/s", write_throughput);
-        println!("读取性能：{:.2} MB/s", read_throughput);
+        println!("写入性能：{write_throughput:.2} MB/s");
+        println!("读取性能：{read_throughput:.2} MB/s");
 
         // 清理
         vfs.release(ctx.clone(), file.inode, fh).await?;

--- a/components/vfs/src/lib.rs
+++ b/components/vfs/src/lib.rs
@@ -14,8 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unsafe_code)]
-
 mod config;
 
 pub use config::Config;

--- a/components/vfs/src/reader.rs
+++ b/components/vfs/src/reader.rs
@@ -453,7 +453,7 @@ mod tests {
         range_map.insert(0..10, 1);
         range_map.insert(10..12, 2);
         range_map.iter().for_each(|(r, v)| {
-            println!("{:?} -> {:?}", r, v);
+            println!("{r:?} -> {v:?}");
         });
     }
 
@@ -486,10 +486,10 @@ mod tests {
         for (r, vs) in virtual_slice_map {
             match vs {
                 VirtualSlice::Hole => {
-                    println!("find hole in range: {:?}", r);
+                    println!("find hole in range: {r:?}");
                 }
                 VirtualSlice::Slice(s) => {
-                    println!("find slice in range: {:?}, slice: {:?}", r, s);
+                    println!("find slice in range: {r:?}, slice: {s:?}");
                 }
             }
         }
@@ -674,7 +674,7 @@ mod tests {
         let write_len = data_manager
             .write(inode, 0, data)
             .await
-            .map_err(|e| println!("{}", e))
+            .map_err(|e| println!("{e}"))
             .unwrap();
 
         let fw = data_manager.find_file_writer(inode).unwrap();
@@ -694,7 +694,7 @@ mod tests {
         let write_len = data_manager
             .write(inode, chunk_size - 3, data)
             .await
-            .map_err(|e| println!("{}", e))
+            .map_err(|e| println!("{e}"))
             .unwrap();
         assert_eq!(write_len, data.len());
 
@@ -724,7 +724,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let format = Format::default();
         let temppath = tempdir.path().to_str().unwrap();
-        meta_config.dsn = format!("rocksdb://:{}", temppath);
+        meta_config.dsn = format!("rocksdb://:{temppath}");
         kiseki_meta::update_format(&meta_config.dsn, format.clone(), true).unwrap();
 
         let meta_engine = kiseki_meta::open(meta_config).unwrap();

--- a/components/vfs/src/writer.rs
+++ b/components/vfs/src/writer.rs
@@ -88,7 +88,7 @@ impl DataManager {
                     fw:       fw_cloned,
                     flush_rx: rx,
                 };
-                flusher.run().await
+                flusher.run().await;
             });
             fw
         });
@@ -109,10 +109,13 @@ impl DataManager {
         data: &[u8],
     ) -> Result<usize> {
         debug!("write {} bytes to ino {}", data.len(), ino);
+        // Clone the `Arc<FileWriter>` out so the DashMap shard lock is released
+        // before the (awaiting) write, rather than held across it.
         let fw = self
             .file_writers
             .get(&ino)
-            .context(LibcSnafu { errno: EBADF })?;
+            .context(LibcSnafu { errno: EBADF })?
+            .clone();
         debug!("Ino({ino}) get file write success");
         let write_len = fw.write(offset, data).await?;
         let current_len = fw.get_length();
@@ -242,7 +245,10 @@ impl FileWriter {
     /// [FileWriter::finish] call.
     fn record_flush_error(&self, err: Error) {
         error!("Ino({}) background flush failed: {}", self.inode, err);
-        let mut guard = self.flush_error.lock().unwrap_or_else(|e| e.into_inner());
+        let mut guard = self
+            .flush_error
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if guard.is_none() {
             *guard = Some(err);
         }
@@ -252,21 +258,21 @@ impl FileWriter {
     fn take_flush_error(&self) -> Option<Error> {
         self.flush_error
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
     }
 
     fn has_flush_error(&self) -> bool {
         self.flush_error
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .is_some()
     }
 
     fn record_published_slice(&self, slice_id: SliceID) {
         self.published_slices
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(slice_id);
     }
 
@@ -469,8 +475,7 @@ impl FileWriter {
             return Err(e);
         }
 
-        let mut write_guard = self.chunk_writers.write().await;
-        write_guard.clear();
+        self.chunk_writers.write().await.clear();
         Ok(())
     }
 
@@ -478,7 +483,7 @@ impl FileWriter {
         let slice_ids = self
             .published_slices
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .iter()
             .copied()
             .collect::<Vec<_>>();
@@ -492,7 +497,7 @@ impl FileWriter {
             file_cache.flush_slice(slice_id).await?;
             self.published_slices
                 .lock()
-                .unwrap_or_else(|e| e.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .remove(&slice_id);
         }
         Ok(())
@@ -626,7 +631,10 @@ impl ChunkWriter {
         self: &Arc<Self>,
         l: &ChunkWriteCtx,
     ) -> (Arc<SliceWriter>, SliceWriterState) {
-        let fw = self.fw.upgrade().unwrap();
+        let fw = self
+            .fw
+            .upgrade()
+            .expect("file writer dropped while chunk writer is active");
         {
             let read_guard = self.slice_writers.read().await;
             for (idx, (_, sw)) in read_guard.iter().rev().enumerate() {
@@ -687,8 +695,10 @@ impl ChunkWriter {
             fw.data_manager.clone(),
         ));
         self.total_slice_count.fetch_add(1, Ordering::AcqRel);
-        let mut write_guard = self.slice_writers.write().await;
-        write_guard.insert(sw._internal_seq, sw.clone());
+        self.slice_writers
+            .write()
+            .await
+            .insert(sw._internal_seq, sw.clone());
         (sw, SliceWriterState::Idle)
     }
 
@@ -780,12 +790,12 @@ enum SliceWriterState {
 impl From<u8> for SliceWriterState {
     fn from(value: u8) -> Self {
         match value {
-            0 => SliceWriterState::Idle,
-            1 => SliceWriterState::Writing,
-            2 => SliceWriterState::Dirty,
-            3 => SliceWriterState::Flushing,
-            4 => SliceWriterState::Committing,
-            5 => SliceWriterState::Done,
+            0 => Self::Idle,
+            1 => Self::Writing,
+            2 => Self::Dirty,
+            3 => Self::Flushing,
+            4 => Self::Committing,
+            5 => Self::Done,
             // Invariant: the backing AtomicU8 is only ever stored/CASed with
             // `SliceWriterState as u8` values in this file, so this arm is
             // unreachable. Returning a made-up state here instead would
@@ -837,7 +847,7 @@ impl SliceWriter {
         seq: u64,
         offset_of_chunk: usize,
         data_manager: Weak<DataManager>,
-    ) -> SliceWriter {
+    ) -> Self {
         Self {
             chunk_index,
             chunk_writer: Arc::downgrade(cw),
@@ -858,8 +868,12 @@ impl SliceWriter {
         offset: usize,
         data: &[u8],
     ) -> Result<usize> {
-        let mut write_guard = self.slice_buffer.write().await;
-        let written = write_guard.write_at(offset, data).await?;
+        let written = self
+            .slice_buffer
+            .write()
+            .await
+            .write_at(offset, data)
+            .await?;
         self.last_modified.store(Instant::now());
         let new_state = if written == 0 {
             before_state
@@ -897,7 +911,11 @@ impl SliceWriter {
             .stage(
                 slice_id,
                 offset,
-                self.data_manager.upgrade().unwrap().file_cache.clone(),
+                self.data_manager
+                    .upgrade()
+                    .expect("data manager dropped during slice flush")
+                    .file_cache
+                    .clone(),
             )
             .await?;
         drop(write_guard);
@@ -969,7 +987,11 @@ impl SliceWriter {
         write_guard
             .flush_v2(
                 slice_id,
-                self.data_manager.upgrade().unwrap().file_cache.clone(),
+                self.data_manager
+                    .upgrade()
+                    .expect("data manager dropped during slice flush")
+                    .file_cache
+                    .clone(),
             )
             .await?;
 
@@ -1145,6 +1167,9 @@ impl SliceWriter {
     }
 
     // get the underlying write buffer's released length and total write length.
+    // The whole body is the critical section (two reads under one guard), so
+    // there is nothing to tighten.
+    #[allow(clippy::significant_drop_tightening)]
     async fn get_flushed_length_and_total_write_length(self: &Arc<Self>) -> (usize, usize) {
         let guard = self.slice_buffer.read().await;
         let flushed_len = guard.flushed_length();
@@ -1157,7 +1182,10 @@ impl SliceWriter {
         inode: Ino,
         meta_engine_ref: MetaEngineRef,
     ) -> Result<()> {
-        let cw = self.chunk_writer.upgrade().unwrap();
+        let cw = self
+            .chunk_writer
+            .upgrade()
+            .expect("chunk writer dropped while committing partial slice");
 
         // write slice meta info to meta engine.
         let slice_id = self.slice_id.load(Ordering::Acquire);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tests"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Why

The workspace had no centralized lint policy — lints were enforced only via ad-hoc `clippy` CLI flags — and the code passed *default* clippy while leaving many idiom/best-practice gaps that default clippy permits (manifest duplication, production `unwrap`/`expect`, over-held async locks, leftover debug code). This PR raises the bar and makes it enforceable going forward, without changing behavior.

## What changed (read commit-by-commit)

1. **`build:` centralized lint policy + manifest inheritance** — a curated `[workspace.lints]` table (`clippy::all` deny + hand-picked pedantic/nursery warnings; noisy lints allowed), `unsafe_code = "deny"` promoted workspace-wide, every crate opts in via `[lints] workspace = true` and inherits `edition`/`version`.
2. **`style:` workspace-wide clippy + idiom cleanup** — mechanical, behavior-preserving fixes (`use_self`, `const fn`, inlined format args, `let..else`, dead `println!`/commented code removed).
3. **`refactor:` harden error handling + tighten async lock scopes** — bare `Weak::upgrade().unwrap()` in the write path → `.expect(...)` with clear invariant messages; lock guards released earlier where `significant_drop_tightening` flagged real slack; intentional holds documented with justified `#[allow]`.
4. **`docs:` mark illustrative vfs examples as `ignore`** — the `KisekiVFS` doc examples were never-compiling pseudo-code; switched `rust,no_run` → `ignore` so they render but stop breaking `cargo test`.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → **clean** (incl. the rocksdb-gated code).
- `cargo +nightly fmt --all --check` → clean.
- `cargo test -p kiseki-vfs` → **62 passed, 0 failed** (doctests now 13 ignored).

## Notes for reviewers

- The lint set is deliberately curated: `default_trait_access` and the `cast_*`/`missing_*_doc` families are allowed because they were high-churn and low-value here. `significant_drop_tightening` is kept because it caught real over-holds; the few false positives (borrow-through-await, deliberate ID-allocation / readdir holds) carry documented `#[allow]`s.
- Local builds of the optional `meta-rocksdb` feature require `CXXFLAGS="-include cstdint"` to work around a `librocksdb-sys` C++ compile issue (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)