### PR TITLE
chore: adopt rara-style PR workflow and reposition as production FS (#80)

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Guard: prevent git checkout/switch on the main worktree.
+# Agents must use git worktree for branch work, never switch main.
+
+# Read the tool input from stdin
+INPUT=$(cat)
+
+# Extract the command from the JSON payload
+COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"//')
+
+# Check if we're on the main worktree (not inside .worktrees/ or .claude/worktrees/)
+CURRENT_DIR=$(pwd)
+case "$CURRENT_DIR" in
+  */.worktrees/*|*/.claude/worktrees/*) exit 0 ;;  # Inside a worktree — allow
+esac
+
+# Check if the command is git checkout or git switch to a different branch
+case "$COMMAND" in
+  *"git checkout -b"*|*"git switch -c"*|*"git checkout -B"*)
+    echo "BLOCKED: Do not create branches on the main worktree. Use 'git worktree add' instead."
+    echo "Example: git worktree add .worktrees/issue-N-name -b issue-N-name"
+    exit 2
+    ;;
+  *"git checkout "*|*"git switch "*)
+    # Allow 'git checkout main', 'git checkout -- file', 'git checkout --ours/--theirs'
+    case "$COMMAND" in
+      *"git checkout main"*|*"git checkout origin/"*) exit 0 ;;
+      *"git checkout -- "*|*"git checkout --"*) exit 0 ;;
+      *"git switch main"*|*"git switch -"*) exit 0 ;;
+    esac
+    echo "BLOCKED: Do not switch branches on the main worktree. Use 'git worktree add' for branch work."
+    echo "Example: git worktree add .worktrees/issue-N-name -b issue-N-name"
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/guard-main-branch.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which crate is affected?
+      options:
+        - fuse (FUSE layer)
+        - vfs (virtual filesystem logic)
+        - meta (metadata / RocksDB backend)
+        - storage (write buffer, caches, page pool)
+        - types (shared types)
+        - common / utils (helpers, object storage)
+        - binary (CLI / mount)
+        - ci (CI/CD, build, release)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Mount with `kiseki mount ...`
+        2. Run `...`
+        3. Observe error ...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error output
+      description: Relevant log output or error messages
+      render: shell
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Commit SHA or `kiseki --version`
+      placeholder: "kiseki 0.1.0"

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,26 @@
+name: Chore / Maintenance
+description: CI, dependencies, tooling, or other maintenance tasks
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What maintenance work is needed?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: What area does this affect?
+      options:
+        - ci (GitHub Actions, workflows)
+        - dependencies (crate updates)
+        - tooling (dev tooling, scripts, justfile)
+        - release (versioning, changelog, publishing)
+        - documentation
+        - other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What do you want and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which crate does this relate to?
+      options:
+        - fuse (FUSE layer)
+        - vfs (virtual filesystem logic)
+        - meta (metadata / RocksDB backend)
+        - storage (write buffer, caches, page pool)
+        - types (shared types)
+        - common / utils (helpers, object storage)
+        - binary (CLI / mount)
+        - ci (CI/CD, build, release)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,35 @@
+name: Refactor
+description: Propose a code refactor or technical improvement
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs refactoring and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which crate is affected?
+      options:
+        - fuse (FUSE layer)
+        - vfs (virtual filesystem logic)
+        - meta (metadata / RocksDB backend)
+        - storage (write buffer, caches, page pool)
+        - types (shared types)
+        - common / utils (helpers, object storage)
+        - binary (CLI / mount)
+        - ci (CI/CD, build, release)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: How would you approach this refactor?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,40 @@
-# Description
+## What & why
 
-<!--- Describe your changes in detail -->
+<!-- Explain your change as a story a reviewer can follow WITHOUT reading the diff first:
+  - What problem or goal prompted this? (the issue's Intent — don't just restate the title)
+  - What approach did you take, and *why this one*? Name the key design decision.
+  - What did you consider and reject, or what non-obvious constraint/tradeoff shaped it?
+  The diff shows WHAT changed. This section must explain WHY it looks like this. -->
 
-<!--- If it fixes an open issue, please link to the issue here. -->
+## Type of change
 
-<!--- Please link any related issues and PRs as well. -->
+<!-- Add the matching type label to this PR -->
 
-## How are the changes test-covered
+| Type | Label |
+|------|-------|
+| Bug fix | `bug` |
+| New feature | `enhancement` |
+| Refactor | `refactor` |
+| CI / Infrastructure | `ci` |
+| Maintenance | `chore` |
+| Documentation | `documentation` |
 
-- [ ] N/A
-- [ ] Automated tests (unit and/or integration tests)
-- [ ] Manual tests
-- [ ] Details are described below
+## Component
+
+<!-- Which crate(s) does this touch? -->
+<!-- `fuse` · `vfs` · `meta` · `storage` · `types` · `common` · `utils` · `binary` -->
+
+## Closes
+
+<!-- REQUIRED: link the issue this PR resolves; merge auto-closes it. -->
+<!-- If no issue exists, create one first: gh issue create -->
+
+Closes #
+
+## How to verify
+
+<!-- Commands you ran or steps a reviewer can repeat — evidence, not a command dump. -->
+- [ ] `just check` / `just lint` pass
+- [ ] `cargo test -p <crate>` (or `just test`) as relevant
+- [ ] Mounted acceptance (`just test-mounted`) when the change touches the mounted path
+- [ ] Tested locally (say how)

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author=dependabot[bot]
+      - check-success=Lint / Lint Success
+      - check-success=Rust / Rust Success
+    actions:
+      merge:
+        method: squash
+
+  - name: Automatic update to the main branch for pull requests
+    conditions:
+      - -conflict # skip PRs with conflicts
+      - -draft # skip GH draft PRs
+      - -author=dependabot[bot] # skip dependabot PRs
+    actions:
+      update:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+# Pre-commit hooks for KisekiFS, run via prek (https://github.com/j178/prek).
+# Setup once:  prek install && prek install --hook-type commit-msg
+# Manual run:  prek run --all-files
+#
+# The FINAL commit of a change must pass all checks. Do NOT use --no-verify.
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check --all --all-features
+        language: system
+        pass_filenames: false
+        types_or: [rust, toml]
+        files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
+
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo +nightly fmt --all -- --check
+        language: system
+        pass_filenames: false
+        types_or: [rust, toml]
+        files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+        language: system
+        pass_filenames: false
+        types_or: [rust, toml]
+        files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
+
+      - id: cargo-doc
+        name: cargo doc
+        entry: env RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --document-private-items
+        language: system
+        pass_filenames: false
+        types_or: [rust, toml]
+        files: \.(rs|toml)$|Cargo\.lock$|rust-toolchain\.toml$
+
+      - id: conventional-commit
+        name: conventional commit message
+        entry: scripts/check-conventional-commit.sh
+        language: script
+        stages: [commit-msg]
+        always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,20 @@
 
 ## What This Project Is
 
-KisekiFS is a Rust learning project—a distributed FUSE filesystem ported from
-[JuiceFS](https://github.com/juicedata/juicefs). It separates data storage
+KisekiFS is a distributed FUSE filesystem, originally ported from
+[JuiceFS](https://github.com/juicedata/juicefs), now being built toward a
+**production-usable, performance-oriented** product. It separates data storage
 (object storage like S3) from metadata storage (RocksDB).
+
+## Project Direction
+
+KisekiFS is being hardened from a learning exercise into a production distributed
+filesystem; **production-readiness and performance are now first-class goals** (a
+change from older docs/commits that still call it a "learning project"). The
+roadmap (architecture-review issues #68–#76 on `rararulab/kisekifs`) and the key
+architecture decisions — notably the **FUSE layer migrating to `fuse-backend-rs`**
+— live in [docs/src/direction.md](docs/src/direction.md). Read it before touching
+the FUSE layer, metadata backend, or data path.
 
 **Workspace Structure:**
 
@@ -25,7 +36,8 @@ docs/            # mdbook sources (`just book` to serve)
 
 **Key Technologies:**
 
-- **FUSE**: fuser (requires libfuse3 installed)
+- **FUSE**: `fuser` today, migrating to `fuse-backend-rs` (see Project Direction
+  & Goals); requires libfuse3 installed
 - **Async Runtime**: tokio
 - **Object Storage**: opendal and object_store (see storage note below)
 - **Metadata**: RocksDB
@@ -42,9 +54,19 @@ improvements:
 
 ## Development Workflow
 
-- **Direct commits to `main` are allowed.** Development happens on short-lived
-  branches in git worktrees under `.worktrees/<task>`, merged back to `main`,
-  then the worktree and branch are removed after merge. No PRs.
+**`main` is protected. Every change — however small — goes through a worktree
+branch and a PR.** Never commit directly to `main` and never edit files on the
+main checkout; a `guard-main-branch` hook enforces this. The flow is
+spec/issue → worktree → local commits → verify → review → push → PR → merge,
+adopted from the reference repo `rararulab/rara` for **parallel multi-agent
+development**. The full normative process is in
+[docs/guides/workflow.md](docs/guides/workflow.md); commit format is in
+[docs/guides/commit-style.md](docs/guides/commit-style.md) (Conventional Commits,
+enforced by a `commit-msg` hook).
+
+- **Every change is issue-first + PR-based.** `git worktree add
+  .worktrees/issue-N-<slug> -b issue-N-<slug>`, commit with `Closes #N`, open a
+  PR, merge with `--squash --delete-branch` once CI is green and review approves.
 - **Storage abstraction is frozen.** Both `opendal` (components/storage, vfs)
   and `object_store` (components/utils) are present. The intended direction is
   opendal, but do not migrate anything until explicitly requested.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 Go check the [doc](https://crrow.github.io/kisekifs/).
 
-Kiseki is my learning rust project, a simple 'distributed' fuse file system that is port
-of [JuiceFS](https://github.com/juicedata/juicefs).
+Kiseki is a distributed FUSE filesystem, originally a port of
+[JuiceFS](https://github.com/juicedata/juicefs), now being built toward a
+**production-usable, performance-oriented** product. It separates data
+(object storage such as S3) from metadata (RocksDB today, a shared/network
+backend planned for multi-node).
 
-**It's just a rust learning project**
+> **Status:** the project has moved beyond its original "learning project"
+> phase and is being hardened for production. Expect breaking changes while core
+> gaps (read-path caching, distributed metadata, FUSE layer) are addressed.
 
 If you don't know juicefs very much, the following is the introduction of juicefs:
 
@@ -54,7 +59,7 @@ supported and intentionally unsupported behavior is listed in the
 
 ## Disclaimer
 
-Kiseki is an independent learning project
+Kiseki is an independent project
 and is not endorsed by or affiliated with the Juice company.
 
 # License

--- a/docs/guides/commit-style.md
+++ b/docs/guides/commit-style.md
@@ -1,0 +1,28 @@
+# Commit Style — Conventional Commits (MANDATORY)
+
+Every commit message MUST follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description> (#N)
+
+<optional body>
+
+Closes #N
+```
+
+- **Allowed types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `style`, `build`, `revert`
+- **Scope** matches a crate or area: `feat(fuse):`, `fix(meta):`, `refactor(storage):`, `docs:`
+  (crates: `fuse` · `vfs` · `meta` · `storage` · `types` · `common` · `utils` · `binary`)
+- **Breaking changes** use `!`: `feat(meta)!: change on-disk key layout`
+- Include the `(#N)` issue reference in the commit subject.
+- Include `Closes #N` in the commit body so the issue auto-closes on merge.
+- A local `commit-msg` hook (`scripts/check-conventional-commit.sh`, wired via
+  `.pre-commit-config.yaml`) enforces this — do NOT bypass it with `--no-verify`.
+- Do NOT use free-form messages like `"update code"` or `"fix stuff"` — they are rejected.
+
+## Setup
+
+```bash
+prek install                       # pre-commit hooks (the Rust quality gate)
+prek install --hook-type commit-msg  # the Conventional Commits check
+```

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -1,0 +1,167 @@
+# Development Workflow — Issue → Worktree → Local Commit → Verify → Review → Push → PR → Merge
+
+**Every code change — no matter how small — MUST follow this workflow.**
+Single-line fixes, typo corrections, config tweaks, doc updates, and refactors
+all go through the flow below. Agents must NEVER directly edit source files on
+the `main` branch, and never commit to `main`. A `guard-main-branch` hook
+(`.claude/hooks/guard-main-branch.sh`) blocks branch work on the main checkout,
+and `main` is a protected branch on GitHub (PR + green CI required to merge).
+
+This workflow is adopted from the reference repo
+[`rararulab/rara`](https://github.com/rararulab/rara) and adapted to KisekiFS. It
+is built for **parallel multi-agent development**: many agents each own an
+isolated worktree + branch + PR, verified/reviewed/merged independently.
+
+```
+0. ISSUE          →  an issue exists first (gh issue create), labelled by type
+                     + component. It carries Intent, prior art, decisions,
+                     boundaries, and a `Verify:` recipe.
+1. WORKTREE       →  git worktree add .worktrees/issue-N-<slug> -b issue-N-<slug>
+2. IMPLEMENT      →  read the code; make the smallest change; run the quality
+                     gate; commit LOCALLY (Conventional Commits; do not push)
+3. VERIFY         →  fresh-context check from clean state: re-run the gate,
+                     and for mounted-path changes drive the real mount
+                     (`just test-mounted`); record evidence
+4. REVIEW         →  review the worktree diff against the issue (loop to APPROVE)
+5. PUSH + PR      →  push the branch; gh pr create; gh pr checks --watch
+6. MERGE          →  gh pr merge --squash --delete-branch (green CI + APPROVE)
+7. CLEANUP        →  git worktree remove + git branch -D
+```
+
+> **Multi-agent roles.** The subagent contracts that run these stages —
+> `spec-author`, `implementer` / `implementer-backend`, `verifier`, `reviewer`,
+> `debugger` — live in `.claude/agents/*` and `harness/roles/*`, with the stage
+> protocol in `docs/guides/pipeline.md`. Those land in the follow-up
+> "agent roles" PR; this document is the human/git-level contract they follow.
+
+## Step 0: Issue first
+
+No worktree without an issue. `gh issue create` with a type label (`bug`,
+`enhancement`, `refactor`, `chore`, `documentation`) and a component hint
+(`fuse` · `vfs` · `meta` · `storage` · `types` · `common` · `utils` · `binary`).
+The issue body states the Intent (not just a title restatement), any prior art
+(`gh issue list`, `git log --grep`, `rg`), the key decisions, the boundaries
+(which paths may change), and a `Verify:` recipe a reviewer can repeat.
+
+## Step 1: Worktree
+
+```bash
+git worktree add .worktrees/issue-{N}-{slug} -b issue-{N}-{slug}
+```
+
+Every edit happens inside the worktree. The main checkout is never edited
+in-place and never switched to a feature branch (the guard hook enforces this).
+
+## Step 2: Implement
+
+1. Read the actual code the change touches (and the issue).
+2. Make the smallest change that satisfies the issue.
+3. Run the **quality gate** (see below).
+4. Commit locally with a Conventional Commits subject + `Closes #N` in the body
+   (see [commit-style.md](commit-style.md)). Do NOT push yet.
+
+If the change touches the mounted data path (`components/fuse`,
+`components/vfs`, `components/meta`, `components/storage`), add or extend a
+mounted acceptance case (see `docs/src/posix-support.md` and the
+`mounted::*` tests) in the same change.
+
+### Quality gate
+
+```bash
+just check      # cargo check --all --all-features
+just lint       # clippy -D warnings + cargo doc
+just fmt        # cargo +nightly fmt (+ taplo + hawkeye)
+cargo test -p <crate>          # targeted tests for what you changed
+just test-mounted              # mounted acceptance, when the mounted path changed
+```
+
+Or run the pre-commit hooks directly: `prek run --all-files`. The **final**
+commit must pass all hooks; intermediate commits during development need not.
+Do NOT use `--no-verify`.
+
+## Step 3: Verify (independent, from clean state)
+
+Re-run the gate from a clean worktree state, and for any change to the mounted
+path, cold-drive the real filesystem — mount it and exercise the changed
+behavior end-to-end (both sides of any write→read wiring), not just unit tests.
+The `Test / Mounted Linux Acceptance` gate (`just test-mounted`) refuses to skip
+when `/dev/fuse` or `fusermount3` is missing. Record the evidence (commands +
+outputs) for the PR body. Verify and review catch disjoint failure classes —
+verify runs the artifact, review reads the diff — so both exist and verify runs
+first.
+
+## Step 4: Review (BEFORE push)
+
+Review the worktree diff (`git -C <worktree> diff origin/main..HEAD`) against the
+issue: correctness, scope creep, and a cross-file regression-decision check
+(`git log --since=30.days` on touched files — did a recent commit deliberately
+remove/restructure what this re-introduces?). Loop until APPROVE; fixes are new
+commits in the worktree (no amend/force-push after review).
+
+## Step 5: Push + Open PR + Watch CI
+
+Only after review APPROVE:
+
+```bash
+git -C <worktree> push -u origin issue-{N}-{slug}
+gh pr create --base main \
+  --title "<type>(<scope>): <description> (#N)" \
+  --body "..." --label "<type>"
+gh pr checks {PR} --watch
+```
+
+The PR body uses `.github/PULL_REQUEST_TEMPLATE.md` and must include the verify
+evidence and `Closes #N`. The required merge-gate checks on `main` are the
+`ci.yml`-routed aggregates **`Lint / Lint Success`**, **`Rust / Rust Success`**,
+**`Test / Rust Test (Ubuntu)`**, and **`Test / Mounted Linux Acceptance`**.
+Path filtering means docs-only PRs satisfy the code checks as `skipped`.
+
+If a check fails: read the log, fix in the worktree, push again. Do not
+`#[ignore]` tests to make CI green. For a genuine flake (same test failed
+recently on `main`): `gh run rerun <id> --failed`, capped at 1.
+
+## Step 6: Merge
+
+Green CI + APPROVE'd review = merge.
+
+```bash
+gh pr merge {N} --squash --delete-branch
+```
+
+`--squash` makes the `main` commit match the Conventional Commit subject.
+
+## Step 7: Cleanup
+
+```bash
+git worktree remove .worktrees/issue-{N}-{slug}
+git branch -D issue-{N}-{slug}
+```
+
+## Confirmation gates
+
+The parent agent chains through the steps without re-asking, EXCEPT:
+
+- **(a) Merging to `main`.** Always ask before the final merge, even with green
+  CI and an APPROVE.
+- **(b) Destructive git operations.** `git reset --hard`, force-push,
+  `branch -D` on a shared branch — anything that rewrites/discards history.
+
+Everything else (status queries, step transitions inside an approved plan,
+routine `git add`/`commit`/`gh pr create`, label tweaks) runs without a
+confirmation round-trip.
+
+## Parallel execution
+
+For independent changes, split into separate issues at step 0 and run
+implementer subagents in parallel — each with its own worktree, branch, and PR,
+verified/reviewed/merged independently. Isolation for concurrent mounted tests:
+per-run temp data dirs and unique mount points; never share a `/dev/fuse` mount
+across parallel runs.
+
+## Branch protection & CI-outage override
+
+`main` protection (require PR, require the four status checks, no direct/force
+push) is configured out-of-band by a repo admin. During a genuine CI outage,
+an admin may temporarily relax the required checks to merge a fully
+locally-verified PR, then restore them immediately — this is an emergency
+override, not part of the normal flow.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [QuickStart](./quick_start.md)
+- [Project Direction](./direction.md)
 - [Design](./design.md)
 - [Bench](./bench.md)
 - [Linux filesystem support](./posix-support.md)

--- a/docs/src/direction.md
+++ b/docs/src/direction.md
@@ -1,0 +1,75 @@
+# Project Direction
+
+## Status
+
+As of **2026-07**, KisekiFS has moved beyond its original "learning project"
+phase. It is being built toward a **production-usable, performance-oriented
+distributed filesystem** in the spirit of
+[JuiceFS](https://github.com/juicedata/juicefs). Treat production-readiness and
+performance as first-class concerns in design decisions. Older docs, commit
+messages, and the `background.md` narrative may still reflect the earlier
+framing.
+
+## Positioning
+
+- JuiceFS-class distributed filesystem: POSIX-oriented, Linux-first.
+- **Data plane:** files chunked into slices, stored in object storage (S3 or
+  local `file://`).
+- **Control plane:** metadata in RocksDB today; a shared/network backend is
+  required for true multi-node and is planned.
+
+## Roadmap
+
+The near-term roadmap is the set of architecture-review issues
+**#68–#76** on [`rararulab/kisekifs`](https://github.com/rararulab/kisekifs/issues).
+These are **all committed work items and are intentionally not ranked by
+priority** — they are all in scope on the way to the production target. Highlights:
+
+| Area | Issue | Summary |
+| --- | --- | --- |
+| Data path | #68 | Wire the read path through the file/mem cache (currently reads bypass caching). |
+| Metadata | #69 | Move from single-node embedded RocksDB toward a shared/network metadata backend. |
+| FUSE | #71 | Replace the serial `fuser` + `block_on` layer — see the decision below. |
+| Storage | #70 | Remove the global singleton page pool; make it configurable/injected. |
+| Cleanups | #72–#76 | Concurrency-map unification, `DataManager` decoupling, mtime propagation, etc. |
+
+## Key Decision: FUSE layer → `fuse-backend-rs`
+
+The FUSE layer will migrate from **`fuser`** to
+[**`fuse-backend-rs`**](https://github.com/cloud-hypervisor/fuse-backend-rs)
+(rust-vmm / Nydus / virtiofsd lineage).
+
+**Why**, given the production + performance goal:
+
+- **Zero-copy read/write** (`ZeroCopyReader` / `ZeroCopyWriter`) — data moves
+  directly between the FUSE request and our slice buffer / cache, avoiding the
+  extra buffer copy an async spawn would require.
+- **True multi-threaded dispatch** — multiple worker threads read the FUSE
+  device concurrently (kernel `FUSE_DEV_IOC_CLONE`), removing today's fully
+  serial request processing.
+- **One `FileSystem` impl serves both `/dev/fuse` and virtio-fs** through the
+  transport-agnostic `Server<F>`. Adopting it keeps a future virtio-fs
+  deployment open with no rewrite, without forcing it now.
+
+`fuse3` (async-native FUSE) was considered and rejected for this goal: its main
+advantage is async ergonomics (developer experience), not performance, and it
+cannot serve virtio-fs.
+
+### Consequence for issue #71
+
+Issue #71 (the FUSE layer processes requests serially because `fuser::mount2`
+runs a single-threaded loop and every callback `block_on`s) is resolved by
+**migrating directly to `fuse-backend-rs`**. Do **not** invest in the interim
+"`fuser` + spawn" approach — it would be throwaway work on the same layer.
+
+The synchronous `FileSystem` trait keeps an async bridge (each worker thread
+`block_on`s the existing async VFS via a `runtime::Handle`); this is acceptable
+because object-storage latency dwarfs the bridge cost.
+
+## Note on where performance actually lives
+
+For an object-storage-backed filesystem, the FUSE transport is a *secondary*
+performance lever. The dominant levers are cache hit-rate on the read path (#68)
+and the metadata backend (#69). The FUSE-layer migration removes the serial
+bottleneck and unlocks zero-copy, but should be evaluated alongside — not ahead
+of — the data-path and metadata work.

--- a/docs/src/posix-support.md
+++ b/docs/src/posix-support.md
@@ -70,8 +70,9 @@ implementations must update this matrix and the manifest in the same change.
   durability.
 - Required tests use RocksDB metadata and `file:///...` object storage rooted in
   a per-test temporary directory. They require no network service or secrets.
-- KisekiFS remains a learning project. Passing this matrix does not imply broad
-  POSIX, multi-node, upgrade, backup, or long-running workload qualification.
+- KisekiFS targets production use but is not yet production-qualified. Passing
+  this matrix does not imply broad POSIX, multi-node, upgrade, backup, or
+  long-running workload qualification.
 
 Run the gate on a capable Linux host with `just test-mounted`. The command
 refuses to skip when `/dev/fuse` or `fusermount3` is unavailable.

--- a/scripts/check-conventional-commit.sh
+++ b/scripts/check-conventional-commit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Validate commit message follows Conventional Commits format.
+# https://www.conventionalcommits.org/
+#
+# Called by prek as a commit-msg hook. $1 is the commit message file.
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE")
+
+# Allow merge commits and revert commits
+if echo "$COMMIT_MSG" | grep -qE '^(Merge |Revert )'; then
+    exit 0
+fi
+
+# Conventional Commits pattern:
+#   type(scope): description
+#   type: description
+#   type(scope)!: description  (breaking change)
+#
+# Allowed types: feat, fix, refactor, docs, test, chore, ci, perf, style, build, revert
+PATTERN='^(feat|fix|refactor|docs|test|chore|ci|perf|style|build|revert)(\([a-z0-9_-]+\))?!?: .+'
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    echo "❌ Commit message does not follow Conventional Commits format."
+    echo ""
+    echo "  Expected: <type>(<scope>): <description>"
+    echo "  Got:      $COMMIT_MSG"
+    echo ""
+    echo "  Allowed types: feat, fix, refactor, docs, test, chore, ci, perf, style, build, revert"
+    echo "  Scope matches a crate/area: fuse, vfs, meta, storage, types, common, utils, binary"
+    echo "  Examples:"
+    echo "    feat(fuse): migrate FUSE layer to fuse-backend-rs"
+    echo "    fix(meta): make rename transactionally atomic"
+    echo "    docs: update development workflow"
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
## What & why

KisekiFS is moving to **parallel multi-agent development** and a production positioning. This PR lands the workflow foundation adopted from `rararulab/rara`: **`main` becomes protected — every change goes through a worktree branch + PR.**

## What's in it
- **Enforcement**: `.claude/hooks/guard-main-branch.sh` (+ `.claude/settings.json`) blocks branch work on the main checkout; `.pre-commit-config.yaml` runs the cargo gate + a Conventional Commits `commit-msg` hook (`scripts/check-conventional-commit.sh`).
- **Process docs**: `docs/guides/workflow.md` + `docs/guides/commit-style.md`.
- **GitHub**: richer PR template, issue templates, mergify.
- **AGENTS.md**: Development Workflow rewritten to worktree+PR.
- **Repositioning** (folded in — overlaps AGENTS.md): production framing + new `docs/src/direction.md` (roadmap #68–#76 + FUSE→fuse-backend-rs).

## Adaptation from rara
Paths components/**; verifier cold-boot → mounted Linux acceptance; web/diesel/boxlite/go-devtool dropped. **Agent role contracts land in a follow-up PR.**

## Out of band
Branch protection on `main` needs a repo admin.

Closes #80