### PR TITLE
ci: skip heavy Rust/Test jobs on docs-only changes (#83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-
-
 defaults:
   run:
     shell: bash
@@ -16,18 +14,61 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether code (vs docs-/config-only) changed. The heavy Rust/Test jobs
+  # are gated on this inside the reusable workflows, so a docs-only PR skips them
+  # while the required aggregate checks (`Rust / Rust Success`, etc.) still report
+  # success — a *skipped* required check counts as passing, but a workflow that
+  # never triggers does not, which is why the filter lives here (and inside the
+  # reusable workflows) rather than in `on.*.paths`.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Path filter
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'tests/**'
+              - 'benches/**'
+              - '.github/workflows/**'
+              - 'justfile'
+              - '.pre-commit-config.yaml'
+              - 'scripts/**'
+
   # Call individual workflow jobs
   lint:
     name: Lint
+    needs: changes
     uses: ./.github/workflows/lint.yml
+    with:
+      run_code: ${{ needs.changes.outputs.code }}
     secrets: inherit
 
   rust:
     name: Rust
+    needs: changes
     uses: ./.github/workflows/rust.yml
+    with:
+      run_code: ${{ needs.changes.outputs.code }}
     secrets: inherit
 
   test:
     name: Test
+    needs: changes
     uses: ./.github/workflows/test.yml
+    with:
+      run_code: ${{ needs.changes.outputs.code }}
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Lint
 
 on:
   workflow_call:
+    inputs:
+      run_code:
+        description: "Whether code (vs docs-only) changed; gates the heavy jobs."
+        type: string
+        default: "true"
 
 concurrency:
   group: lint-${{ github.event.pull_request.number || github.sha }}
@@ -27,6 +32,7 @@ jobs:
   rust-format:
     name: Rust Format
     runs-on: ubuntu-latest
+    if: inputs.run_code == 'true'
     outputs:
       rust-version: ${{ steps.rust-version.outputs.version }}
     steps:
@@ -75,10 +81,9 @@ jobs:
     needs: [rust-format]
     if: always()
     steps:
-      - name: Check all lint jobs status
-        run: |
-          if [[ "${{ needs.rust-format.result }}" != "success" ]]; then
-            echo "One or more lint jobs failed"
-            exit 1
-          fi
-          echo "All lint jobs passed successfully"
+      # A skipped job (docs-only change) counts as passing; only a real
+      # failure/cancellation blocks.
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: rust-format

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,11 @@ name: Rust
 
 on:
   workflow_call:
+    inputs:
+      run_code:
+        description: "Whether code (vs docs-only) changed; gates the heavy jobs."
+        type: string
+        default: "true"
 
 concurrency:
   group: rust-${{ github.event.pull_request.number || github.sha }}
@@ -45,6 +50,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     needs: rust-version
+    if: inputs.run_code == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -74,6 +80,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     needs: rust-version
+    if: inputs.run_code == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -102,6 +109,7 @@ jobs:
   miri:
     name: Miri buffer ownership
     runs-on: ubuntu-latest
+    if: inputs.run_code == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -132,7 +140,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     needs: rust-version
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.run_code == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -184,6 +192,7 @@ jobs:
     name: Dependency Advisories
     runs-on: ubuntu-latest
     needs: rust-version
+    if: inputs.run_code == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -208,15 +217,10 @@ jobs:
     needs: [clippy, docs, miri, coverage, advisories]
     if: always()
     steps:
-      - name: Check all Rust jobs status
-        run: |
-          if [[ "${{ needs.clippy.result }}" != "success" || \
-                "${{ needs.docs.result }}" != "success" || \
-                "${{ needs.miri.result }}" != "success" || \
-                "${{ needs.advisories.result }}" != "success" || \
-                ("${{ needs.coverage.result }}" != "success" && \
-                 "${{ needs.coverage.result }}" != "skipped") ]]; then
-            echo "One or more Rust jobs failed"
-            exit 1
-          fi
-          echo "All Rust jobs passed successfully"
+      # A skipped job (docs-only change, or coverage off-PR) counts as passing;
+      # only a real failure/cancellation blocks. re-actors/alls-green encapsulates
+      # that logic instead of hand-rolled result-matching.
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: clippy, docs, miri, coverage, advisories

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      run_code:
+        description: "Whether code (vs docs-only) changed; gates the heavy jobs."
+        type: string
+        default: "true"
 
 concurrency:
   group: test-${{ github.event.pull_request.number || github.sha }}
@@ -46,6 +51,7 @@ jobs:
     name: Rust Test (Ubuntu)
     runs-on: ubuntu-latest
     needs: rust-version
+    if: inputs.run_code == 'true'
     # nextest runs cases in separate processes; keep them from sharing the
     # production disk-pool mmap path. DiskPagePool has dedicated unit tests.
     env:
@@ -81,6 +87,7 @@ jobs:
   mounted-test:
     name: Mounted Linux Acceptance
     runs-on: ubuntu-latest
+    if: inputs.run_code == 'true'
     timeout-minutes: 25
     steps:
       - name: Checkout code
@@ -118,10 +125,9 @@ jobs:
     needs: [rust-test, mounted-test]
     if: always()
     steps:
-      - name: Check all test jobs status
-        run: |
-          if [[ "${{ needs.rust-test.result }}" != "success" || "${{ needs.mounted-test.result }}" != "success" ]]; then
-            echo "One or more test jobs failed"
-            exit 1
-          fi
-          echo "All test jobs passed successfully"
+      # A skipped job (docs-only change) counts as passing; only a real
+      # failure/cancellation blocks.
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: rust-test, mounted-test


### PR DESCRIPTION
## What & why
Docs-/config-only PRs ran the **entire** heavy suite (Clippy, Miri, Rust Test, ~20min Mounted Acceptance) because `ci.yml` called the reusable rust/test/lint workflows unconditionally. #81 sat ~20min on the mounted gate for a docs change.

## Approach — established actions, no hand-rolled logic
- **`dorny/paths-filter`** `changes` job in `ci.yml` → `code` boolean, passed as a `run_code` input into each reusable workflow.
- Heavy jobs gated with `if: inputs.run_code == 'true'`.
- **`re-actors/alls-green`** replaces the aggregate gates (`allowed-skips`), so docs-only PRs satisfy the required checks (`Lint/Rust/Test Success`) as **skipped** in seconds.

Filtering lives *inside* the reusable workflows (not `on.*.paths`) so the required aggregate checks always report — a skipped required check passes; a workflow that never triggers blocks forever.

## Verify
- **This PR** touches `.github/workflows/**` → `code=true` → full suite runs green (validates the change end-to-end).
- **Next docs-only PR**: heavy jobs show `skipped`, `Rust / Rust Success` etc. pass, mergeable without the 20min wait.

Closes #83